### PR TITLE
Feat 98 Development Authentication

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -10,7 +10,7 @@ BASE_DIR = os.path.dirname(os.path.dirname(os.path.abspath(__file__)))
 SECRET_KEY = os.environ.get("SECRET_KEY") or get_random_string(50, string.printable)
 
 # don't run with debug turned on in production!
-DEBUG = os.environ.get("DEBUG", default=False)
+DEBUG = os.environ.get("DEBUG") or False
 
 # Application definition
 INSTALLED_APPS = [
@@ -29,8 +29,11 @@ WSGI_APPLICATION = "app.wsgi.application"
 
 AUTH_USER_MODEL = "solo_rog_api.User"
 
+# use client SSL certificate (CAC) authentication by default,
+# but replace with a development backend if DEBUG
 AUTHENTICATION_BACKENDS = ["solo_rog_api.authentication.CACAuthenticationBackend"]
-
+if DEBUG:
+    AUTHENTICATION_BACKENDS = ["solo_rog_api.authentication.DevAuthenticationBackend"]
 REST_FRAMEWORK = {
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication"

--- a/backend/solo_rog_api/authentication.py
+++ b/backend/solo_rog_api/authentication.py
@@ -36,3 +36,14 @@ class CACAuthenticationBackend(BaseBackend):
         user, _ = User.objects.get_or_create(username=dodid)
 
         return user
+
+
+class DevAuthenticationBackend(BaseBackend):
+    def authenticate(self, request) -> AbstractUser:  # type: ignore # pylint: disable=arguments-differ
+        # in development, with DEBUG turned on, authenticate
+        # as the user specified in the Authorization header
+        username = request.META.get("HTTP_AUTHORIZATION")
+        if not username:
+            raise AuthenticationFailed()
+        user, _ = User.objects.get_or_create(username=username.strip())
+        return user

--- a/deploy/compose/docker-compose.override.yml
+++ b/deploy/compose/docker-compose.override.yml
@@ -4,8 +4,11 @@ services:
   backend:
     volumes:
       - ../../backend:/app/
+    command: "python manage.py runserver 0.0.0.0:8000"
     ports:
       - "8000:8000"
+    environment:
+      - DEBUG=True
 
   frontend:
     build:
@@ -15,9 +18,9 @@ services:
       - "3000:3000"
     volumes:
       - ../../frontend/src:/app/src
-    env_file: 
+    env_file:
       - ./.env
-    environment: 
+    environment:
       - REACT_APP_API_DOMAIN=$DEV_API_DOMAIN
       - REACT_APP_AUTH_DOMAIN=$DEV_API_DOMAIN
       - REACT_APP_API_PROTOCOL=http

--- a/deploy/compose/docker-compose.yml
+++ b/deploy/compose/docker-compose.yml
@@ -3,7 +3,7 @@ version: '3.4'
 services:
   db:
     image: postgres
-    env_file: 
+    env_file:
       - ./.env
 
   migrate:
@@ -11,20 +11,22 @@ services:
     env_file: 
       - ./.env
     command: "python manage.py migrate"
-    depends_on: 
+    depends_on:
       - db
 
   backend:
     build: ../../backend
-    env_file: 
+    env_file:
       - ./.env
-    depends_on: 
+    depends_on:
       - migrate
+    environment:
+      - DEBUG=
 
   frontend:
     build:
       context: ../../frontend
-      args: 
+      args:
         - API_DOMAIN=$API_DOMAIN
         - API_PROTOCOL=https
         - AUTH_DOMAIN=$AUTH_DOMAIN
@@ -35,6 +37,5 @@ services:
       - backend
     volumes:
       - $SSL_KEYS_VOLUME_ROOT:/etc/ssl/
-    env_file: 
+    env_file:
       - ./.env
-


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- [x] review and update SSAG documentation if needed.

## Summary of Changes
This pull request…
- closes #98 
- adds a development authentication backend
- overrides CAC authentication backend in Django settings *only* when DEBUG is enabled
- configures frontend to interact with development authentication backend *only* when development mode is enabled

## Testing
To verify the changes proposed in this pull request…
1. run unit tests
1. start development environment
1. attempt to authenticate, provide a username to the prompt

## Screenshots
<img width="1390" alt="Screen Shot 2020-02-23 at 12 42 57 PM" src="https://user-images.githubusercontent.com/59582489/75117214-873ae880-563d-11ea-9e3b-868a82fe6895.png">
<img width="1422" alt="Screen Shot 2020-02-23 at 12 43 08 PM" src="https://user-images.githubusercontent.com/59582489/75117218-8a35d900-563d-11ea-91cd-0f97956e8706.png">

