### PR TITLE
#112 Feat autoscaling group policy in Terraform

### DIFF
--- a/deploy/staging/application/README.MD
+++ b/deploy/staging/application/README.MD
@@ -1,7 +1,8 @@
-# Terraform Applicaiton setup
+# Terraform Application setup
 
 1. `terraform init -backend-config=application-stage.config`
 1. `terraform validate`
+1. `terraform fmt`
 1. `tflint`
 1. `terraform plan -var-file=application-stage.tfvars`
 1. `terraform apply -auto-approve -var-file=application-stage.tfvars`

--- a/deploy/staging/platform/ecs.tf
+++ b/deploy/staging/platform/ecs.tf
@@ -56,9 +56,9 @@ resource "aws_ecs_cluster" "ecs_cluster" {
 
 // 2. Network Load Balancer reside in the public subnet
 resource "aws_lb" "nlb" {
-  name                             = "solo-stage-tf-nlb"
-  internal                         = false
-  load_balancer_type               = "network"
+  name               = "solo-stage-tf-nlb"
+  internal           = false
+  load_balancer_type = "network"
 
   subnet_mapping {
     subnet_id     = data.terraform_remote_state.infrastructure_stage.outputs.public_subnet_id

--- a/deploy/staging/platform/outputs.tf
+++ b/deploy/staging/platform/outputs.tf
@@ -4,6 +4,9 @@ output "vpc_id" {
 output "ecs_cluter" {
   value = aws_ecs_cluster.ecs_cluster.id
 }
+output "ecs_cluster_name" {
+  value = aws_ecs_cluster.ecs_cluster.name
+}
 output "security_group_nlb" {
   value = aws_security_group.nlb_sg.id
 }


### PR DESCRIPTION
Add autoscaling targets and policy for both frontend and worker. Add ec_cluster_name to platform outputs. Adds step to README.MD.

Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
~~review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
1. _Updates Readme file for application to add `terraform fmt` so the lines of code I wrote will automatically format itself to a canonical format and style._
1. _Added appautoscaling target and appautoscaling policy for both the frontend and worker ECS services within the staging cluster._
1. _Added an output file in the platform outputs file to retrieve the ecs cluster name in order to be used for the autoscaling._

## Testing
To verify the changes proposed in this pull request…
1. _Followed the Terraform steps to verify that the autoscaling policy applied within each service._
1. _Set the scaling average CPU target to 10% with a 5 second cool-down and applied the following command to stress the system using ApacheBench and initiate a scale-up event: 
`ab -n 100000 -c 200  https://stage.solo.code.mil/`._
1. _Observed the service scale up the tasks in response to the increased traffic according to the scaling policy._
1. _Observed the service scale down the number of tasks as the traffic decreased._

## Screenshots
_Attach relevant before and after screenshots here._
![image](https://user-images.githubusercontent.com/59582535/75948532-8b92ad00-5e58-11ea-9279-c72be3c10575.png)
![image](https://user-images.githubusercontent.com/59582535/75948552-9cdbb980-5e58-11ea-8883-c28cfcb97984.png)
![image](https://user-images.githubusercontent.com/59582535/75948576-b5e46a80-5e58-11ea-8533-7b1bef6f5dfe.png)
![image](https://user-images.githubusercontent.com/59582535/75948637-dd3b3780-5e58-11ea-9691-9bb7488aba41.png)
