### PR TITLE
Feat 135 display table of documents on status page

### DIFF
--- a/frontend/src/components/StatusPage/StatusPage.tsx
+++ b/frontend/src/components/StatusPage/StatusPage.tsx
@@ -1,7 +1,100 @@
-import React from "react";
+import React, { useMemo, useCallback, useEffect, useState } from "react";
+import { Column, Row, SortingRule } from "react-table";
+import { formatDistanceToNow, parseISO } from "date-fns";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faPlus, faMinus } from "@fortawesome/free-solid-svg-icons";
+import { Document } from "solo-types";
+import { Table } from "components";
+import useAuthContext from "context/AuthContext";
+import createFakeDocs from "./fakeDoc";
 
 const StatusPage: React.FC = () => {
-  return <div>Status Page</div>;
+  const { apiCall } = useAuthContext();
+  const [docs, setDocs] = useState<Document[]>([]);
+  const [sortBy, setSortBy] = useState<SortingRule<Document>[]>([]);
+
+  const fetchDocuments = useCallback(async () => {
+    try {
+      const params = new URLSearchParams();
+      const sort = sortBy[0];
+      if (sort?.id) {
+        params.set("sort", sort?.id);
+      }
+      if (sort?.desc) {
+        params.set("desc", "true");
+      }
+      const query = params.toString();
+      const queryString = query ? `?${query}` : "";
+      const url = `/documents${queryString}`;
+      setDocs(
+        await apiCall<Document[]>(url, {
+          method: "GET"
+        })
+      );
+    } catch (e) {
+      // use fake data until api is implemented
+      setDocs(createFakeDocs(10));
+    }
+  }, [setDocs, sortBy, apiCall]);
+
+  useEffect(() => {
+    fetchDocuments();
+  }, [setSortBy, sortBy, fetchDocuments]);
+
+  const columns: Column<Document>[] = useMemo(
+    () => [
+      {
+        Header: "Details",
+        Cell: ({ row }) => (
+          <span {...row.getToggleRowExpandedProps()}>
+            <FontAwesomeIcon icon={row.isExpanded ? faMinus : faPlus} />
+          </span>
+        )
+      },
+      {
+        Header: "SDN",
+        accessor: "sdn"
+      },
+      {
+        Header: "Service Request #",
+        accessor: "service_request"
+      },
+      {
+        Header: "Commodity",
+        id: "commodity",
+        accessor: () => "Motor T"
+      },
+      {
+        Header: "Status",
+        disableSortBy: true,
+        accessor: "status[0].dic[0].desc"
+      },
+      {
+        Header: "Nomenclature",
+        id: "nomen",
+        accessor: "part[0].nomen"
+      },
+      {
+        Header: "Last Updated",
+        id: "status_date",
+        accessor: ({ status }) =>
+          `${formatDistanceToNow(parseISO(status[0].status_date))} ago`
+      }
+    ],
+    []
+  );
+
+  return (
+    <div className="tablet:margin-x-8 overflow-x-auto">
+      <Table<Document>
+        columns={columns}
+        data={docs}
+        renderSubComponent={(row: Row<Document>) => <div>placeholder</div>}
+        onSort={setSortBy}
+        initialSortBy={sortBy}
+      />
+    </div>
+  );
 };
 
 export default StatusPage;

--- a/frontend/src/components/StatusPage/__tests__/__snapshots__/statusPage.spec.tsx.snap
+++ b/frontend/src/components/StatusPage/__tests__/__snapshots__/statusPage.spec.tsx.snap
@@ -2,8 +2,279 @@
 
 exports[`StatusPage component matches snapshot 1`] = `
 <DocumentFragment>
-  <div>
-    Status Page
+  <div
+    class="tablet:margin-x-8 overflow-x-auto"
+  >
+    <table
+      class="usa-table grid-col-12 usa-table--borderless"
+      role="table"
+    >
+      <thead>
+        <tr
+          role="row"
+        >
+          <th
+            colspan="1"
+            role="columnheader"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Details
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              SDN
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Service Request #
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Commodity
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Status
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Nomenclature
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Last Updated
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        role="rowgroup"
+      >
+        <tr
+          role="row"
+        >
+          <td
+            class="td"
+            role="cell"
+          >
+            <span
+              style="cursor: pointer;"
+              title="Toggle Row Expanded"
+            >
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-plus fa-w-14 "
+                data-icon="plus"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M416 208H272V64c0-17.67-14.33-32-32-32h-32c-17.67 0-32 14.33-32 32v144H32c-17.67 0-32 14.33-32 32v32c0 17.67 14.33 32 32 32h144v144c0 17.67 14.33 32 32 32h32c17.67 0 32-14.33 32-32V304h144c17.67 0 32-14.33 32-32v-32c0-17.67-14.33-32-32-32z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            M0000000000000
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            5
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            Motor T
+          </td>
+          <td
+            class="td"
+            role="cell"
+          />
+          <td
+            class="td"
+            role="cell"
+          >
+            Switch, rotary, 24V dc waterproof
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            3 days ago
+          </td>
+        </tr>
+      </tbody>
+    </table>
   </div>
 </DocumentFragment>
 `;

--- a/frontend/src/components/StatusPage/__tests__/statusPage.spec.tsx
+++ b/frontend/src/components/StatusPage/__tests__/statusPage.spec.tsx
@@ -1,10 +1,113 @@
 import React from "react";
-import { render } from "test-utils";
+import { render, wait } from "test-utils";
+import { defaultDoc } from "../fakeDoc";
 import StatusPage from "../StatusPage";
+import { fireEvent } from "@testing-library/react";
+
+// jest.mock("../StatusPageDetails", () => () => <div>testdetails</div>);
 
 describe("StatusPage component", () => {
-  it("matches snapshot", () => {
-    const { asFragment } = render(<StatusPage />);
-    expect(asFragment()).toMatchSnapshot();
+  const fetchMock = jest.fn();
+
+  beforeEach(() => {
+    fetchMock.mockResolvedValue([defaultDoc]);
+  });
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it("matches snapshot", async () => {
+    const { asFragment } = render(<StatusPage />, {
+      authContext: {
+        apiCall: fetchMock
+      }
+    });
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      expect(asFragment()).toMatchSnapshot();
+    });
+  });
+
+  it("requests documents from api on initial render", async () => {
+    fetchMock.mockResolvedValue([]);
+    render(<StatusPage />, {
+      authContext: {
+        apiCall: fetchMock
+      }
+    });
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalled();
+      expect(fetchMock.mock.calls[0][0]).toEqual("/documents");
+      expect(fetchMock.mock.calls[0][1]).toMatchObject({
+        method: "GET"
+      });
+    });
+  });
+
+  it("shows document details when toggled", async () => {
+    const { getByTitle, queryByText } = render(<StatusPage />, {
+      authContext: {
+        apiCall: fetchMock
+      }
+    });
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const toggleBtn = getByTitle("Toggle Row Expanded");
+    fireEvent.click(toggleBtn);
+    await wait(() => {
+      expect(queryByText("placeholder")).toBeInTheDocument();
+    });
+  });
+
+  it("re-fetches documents on table sort change", async () => {
+    const { getByText } = render(<StatusPage />, {
+      authContext: {
+        apiCall: fetchMock
+      }
+    });
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const lastUpdatedHeader = getByText(/^Last Updated/);
+    fireEvent.click(lastUpdatedHeader);
+    await wait(() => {
+      // first call was on render, this is second
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][0]).toEqual("/documents?sort=status_date");
+    });
+    fireEvent.click(lastUpdatedHeader);
+    await wait(() => {
+      // sort by is now desc
+      expect(fetchMock).toHaveBeenCalledTimes(3);
+      expect(fetchMock.mock.calls[2][0]).toEqual(
+        "/documents?sort=status_date&desc=true"
+      );
+    });
+    fireEvent.click(lastUpdatedHeader);
+    await wait(() => {
+      // sort by is undefined
+      expect(fetchMock).toHaveBeenCalledTimes(4);
+      expect(fetchMock.mock.calls[3][0]).toEqual("/documents");
+    });
+  });
+
+  it("renders 10 fake documents on fetch error for now", async () => {
+    fetchMock.mockRejectedValue(new Error());
+    const { getAllByTitle } = render(<StatusPage />, {
+      authContext: {
+        apiCall: fetchMock
+      }
+    });
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalled();
+    });
+    const allRowToggles = getAllByTitle("Toggle Row Expanded");
+    expect(allRowToggles.length).toEqual(10);
   });
 });

--- a/frontend/src/components/StatusPage/fakeDoc.ts
+++ b/frontend/src/components/StatusPage/fakeDoc.ts
@@ -1,0 +1,121 @@
+import { Document } from "solo-types";
+import { parseISO, sub } from "date-fns";
+
+export const defaultDoc = {
+  id: 1,
+  part: [
+    {
+      id: 2,
+      nsn: "5930015931045",
+      nomen: "Switch, rotary, 24V dc waterproof",
+      uom: "ea",
+      document: [1]
+    }
+  ],
+  status: [
+    {
+      id: 1,
+      dic: {
+        id: 1,
+        code: "AS1",
+        desc: "Shipping Status",
+        status: [1]
+      },
+      status_date: "2020-03-06T13:01:21-05:00",
+      key_and_transmit_date: null,
+      esd: null,
+      qty: 5,
+      document: 1,
+      user: null
+    },
+    {
+      id: 2,
+      dic: {
+        id: 1,
+        code: "AS2",
+        desc: "Shipping Status",
+        status: [1]
+      },
+      status_date: "2020-03-06T13:01:21-05:00",
+      key_and_transmit_date: null,
+      esd: null,
+      qty: 5,
+      document: 1,
+      user: null
+    }
+  ],
+  address: [
+    {
+      id: 7,
+      address_type: "1",
+      name: "requestor",
+      ric: "SMS",
+      addy1: "addy1",
+      addy2: "addy2",
+      addy3: "addy3",
+      city: "Arlington",
+      state: "VA",
+      zip: "22202",
+      country: "United States",
+      document: [1]
+    },
+    {
+      id: 8,
+      address_type: "2",
+      name: "AAC-Residence Inn Arlington Pentagon City: Rm 1103",
+      ric: "5E3",
+      addy1: "Residence Inn Arlington Pentagon City: Rm 1103",
+      addy2: "550 Army Navy Dr",
+      addy3: "addy3",
+      city: "Arlington",
+      state: "VA",
+      zip: "22202",
+      country: "United States",
+      document: [1]
+    },
+    {
+      id: 9,
+      address_type: "3",
+      name: "AAC-M30300",
+      ric: "SMS",
+      addy1: "addy1",
+      addy2: "addy2",
+      addy3: "addy3",
+      city: "Arlington",
+      state: "VA",
+      zip: "22202",
+      country: "United States",
+      document: [1]
+    },
+    {
+      id: 10,
+      address_type: "4",
+      name: "AAC-M30300",
+      ric: "5E3",
+      addy1: "addy1",
+      addy2: "addy2",
+      addy3: "bldg 24006 Montezuma",
+      city: "Arlington",
+      state: "VA",
+      zip: "22202",
+      country: "United States",
+      document: [1]
+    }
+  ],
+  sdn: "M0000000000000",
+  service_request: 5
+};
+
+const createFakeDocuments = (count: number = 20): Document[] => {
+  return Array.from({ length: count }).map(() => ({
+    ...defaultDoc,
+    status: defaultDoc.status.map(stat => ({
+      ...stat,
+      status_date: sub(parseISO(stat.status_date), {
+        days: Math.floor(Math.random() * 10)
+      }).toISOString()
+    }))
+  }));
+};
+
+export default createFakeDocuments;

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -14,8 +14,8 @@ import TableBody from "./TableBody";
 interface TableProps<T extends object> {
   columns: Column<T>[];
   data: T[];
-  initialSortBy: SortingRule<T>;
-  onSort: (sortBy: SortingRule<T>) => void;
+  initialSortBy: SortingRule<T>[];
+  onSort: (sortBy: SortingRule<T>[]) => void;
   renderSubComponent?: (row: Row<T>) => JSX.Element;
 }
 
@@ -39,14 +39,14 @@ const Table = <T extends object>({
       columns,
       data,
       manualSortBy: true,
-      initialState: { sortBy: [initialSortBy] }
+      initialState: { sortBy: initialSortBy }
     },
     useSortBy,
     useExpanded
   );
 
   useEffect(() => {
-    onSort(sortBy[0]);
+    onSort(sortBy);
   }, [sortBy, onSort]);
 
   return (

--- a/frontend/src/components/Table/__tests__/Table.spec.tsx
+++ b/frontend/src/components/Table/__tests__/Table.spec.tsx
@@ -37,7 +37,7 @@ describe("Table component", () => {
       <Table<TestDoc>
         columns={columns}
         data={data}
-        initialSortBy={{ id: "value" }}
+        initialSortBy={[]}
         onSort={onSortMock}
         renderSubComponent={onRenderSubMock}
       />
@@ -50,7 +50,7 @@ describe("Table component", () => {
       <Table<TestDoc>
         columns={columns}
         data={data}
-        initialSortBy={{ id: "value" }}
+        initialSortBy={[{ id: "value" }]}
         onSort={onSortMock}
         renderSubComponent={onRenderSubMock}
       />
@@ -62,14 +62,16 @@ describe("Table component", () => {
     fireEvent.click(sortHeader);
     await wait(() => {
       expect(onSortMock).toHaveBeenCalledTimes(2);
-      expect(onSortMock.mock.calls[1][0]).toMatchObject({
-        id: "value"
-      });
+      expect(onSortMock.mock.calls[1][0]).toMatchObject([
+        {
+          id: "value"
+        }
+      ]);
     });
     fireEvent.click(sortHeader);
     await wait(() => {
       expect(onSortMock).toHaveBeenCalledTimes(3);
-      expect(onSortMock.mock.calls[2][0]).toBeUndefined();
+      expect(onSortMock.mock.calls[2][0]).toEqual([]);
     });
   });
 
@@ -78,7 +80,7 @@ describe("Table component", () => {
       <Table<TestDoc>
         columns={columns}
         data={data}
-        initialSortBy={{ id: "value" }}
+        initialSortBy={[]}
         onSort={onSortMock}
         renderSubComponent={onRenderSubMock}
       />

--- a/frontend/src/components/Table/__tests__/__snapshots__/Table.spec.tsx.snap
+++ b/frontend/src/components/Table/__tests__/__snapshots__/Table.spec.tsx.snap
@@ -53,7 +53,7 @@ exports[`Table component matches snapshot 1`] = `
               data-prefix="fas"
               focusable="false"
               role="img"
-              style="visibility: visible;"
+              style="visibility: hidden;"
               viewBox="0 0 448 512"
               xmlns="http://www.w3.org/2000/svg"
             >

--- a/frontend/src/solo-uswds/Button.tsx
+++ b/frontend/src/solo-uswds/Button.tsx
@@ -23,7 +23,8 @@ export const Button: React.FC<ButtonProps> = ({
   inverse = false,
   big = false,
   disabled = false,
-  className = ""
+  className = "",
+  ...rest
 }) => {
   const [isHovered, setIsHovered] = useState(false);
 
@@ -44,6 +45,7 @@ export const Button: React.FC<ButtonProps> = ({
         "usa-button--base": color === "base",
         "usa-button--big": big
       })}
+      {...rest}
     >
       {children}
     </button>


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
~~[x] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- closes #135 
- add table to status page
- setup api call
- setup manual sorting via api calls
- use fake data for now until api implemented
- make uswds button more generic
- update table to account for, and avoid, multi-column sorting

## Testing
To verify the changes proposed in this pull request…
1. Frontend unit tests

## Screenshots
<img width="1454" alt="image" src="https://user-images.githubusercontent.com/59582489/76265801-ef8fe980-623b-11ea-9a12-df3714f7f926.png">

