### PR TITLE
Feat 143 add navigation link to d6t page and add placeholder d6t page component

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -81,6 +81,7 @@
       "src/App.tsx",
       "src/components/.*index.ts",
       "src/solo-uswds/.*index.ts",
+      "src/context/.*index.ts",
       "src/pages/.*index.ts",
       "src/components/.*fakeDoc.ts",
       "src/solo-types/.*.ts"

--- a/frontend/src/components/Navbar/Navbar.tsx
+++ b/frontend/src/components/Navbar/Navbar.tsx
@@ -6,8 +6,10 @@ import {
   HeaderNavLink,
   HeaderLogo
 } from "solo-uswds";
+import { useAuthContext } from "context";
 
 const Navbar: React.FC = () => {
+  const { authenticated } = useAuthContext();
   const [isOpen, setIsOpen] = useState(false);
 
   const toggleOpen = useCallback(() => {
@@ -25,9 +27,16 @@ const Navbar: React.FC = () => {
         </button>
       </HeaderNavbar>
       <HeaderNav isOpen={isOpen} onClose={toggleOpen}>
-        <HeaderNavLink to="/" exact onClick={close}>
-          Status
-        </HeaderNavLink>
+        {authenticated && (
+          <>
+            <HeaderNavLink to="/" exact onClick={close}>
+              Status
+            </HeaderNavLink>
+            <HeaderNavLink to="/d6t" exact onClick={close}>
+              Enter Receipt (D6T)
+            </HeaderNavLink>
+          </>
+        )}
       </HeaderNav>
     </Header>
   );

--- a/frontend/src/components/Navbar/__tests__/__snapshots__/navbar.spec.tsx.snap
+++ b/frontend/src/components/Navbar/__tests__/__snapshots__/navbar.spec.tsx.snap
@@ -47,19 +47,6 @@ exports[`Navbar component matches snapshot 1`] = `
               src="close.svg"
             />
           </button>
-          <li
-            class="usa-nav__primary-item"
-          >
-            <a
-              aria-current="page"
-              class="usa-nav__link usa-current"
-              href="/"
-            >
-              <span>
-                Status
-              </span>
-            </a>
-          </li>
         </ul>
       </nav>
     </div>

--- a/frontend/src/components/Navbar/__tests__/navbar.spec.tsx
+++ b/frontend/src/components/Navbar/__tests__/navbar.spec.tsx
@@ -24,7 +24,11 @@ describe("Navbar component", () => {
   });
 
   it("clicking a link closes the menu", async () => {
-    const { container, getByText } = render(<Navbar />);
+    const { container, getByText } = render(<Navbar />, {
+      authContext: {
+        authenticated: true
+      }
+    });
     const primaryNavSelector = '[aria-label="Primary navigation"]';
     const menuButton = getByText("Menu");
     fireEvent.click(menuButton);

--- a/frontend/src/context/index.ts
+++ b/frontend/src/context/index.ts
@@ -1,0 +1,1 @@
+export { default as useAuthContext } from "./AuthContext";

--- a/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
+++ b/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
@@ -1,0 +1,5 @@
+import React from "react";
+
+const EnterReceiptPage: React.FC = () => <div>Enter Receipt</div>;
+
+export default EnterReceiptPage;

--- a/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
@@ -1,0 +1,9 @@
+// Jest Snapshot v1, https://goo.gl/fbAQLP
+
+exports[`EnterReceiptPage Component matches snapshot 1`] = `
+<DocumentFragment>
+  <div>
+    Enter Receipt
+  </div>
+</DocumentFragment>
+`;

--- a/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPage.spec.tsx
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPage.spec.tsx
@@ -1,0 +1,10 @@
+import React from "react";
+import EnterReceiptPage from "../EnterReceiptPage";
+import { render } from "test-utils";
+
+describe("EnterReceiptPage Component", () => {
+  it("matches snapshot", () => {
+    const { asFragment } = render(<EnterReceiptPage />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+});

--- a/frontend/src/pages/EnterReceiptPage/index.ts
+++ b/frontend/src/pages/EnterReceiptPage/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./EnterReceiptPage";

--- a/frontend/src/pages/Layout/Layout.tsx
+++ b/frontend/src/pages/Layout/Layout.tsx
@@ -1,8 +1,14 @@
 import React from "react";
 import { Switch, Route } from "react-router-dom";
 import { OfficialSiteBanner } from "solo-uswds";
-import { Navbar, HomeRoute } from "components";
-import { PostLogoutPage, StatusPage, LoginPage, HomePage } from "pages";
+import { Navbar, HomeRoute, AuthRoute } from "components";
+import {
+  PostLogoutPage,
+  StatusPage,
+  LoginPage,
+  HomePage,
+  EnterReceiptPage
+} from "pages";
 
 const Layout: React.FC = () => (
   <>
@@ -14,6 +20,12 @@ const Layout: React.FC = () => (
         path="/"
         unAuthComponent={LoginPage}
         authComponent={StatusPage}
+      />
+      <AuthRoute
+        exact
+        path="/d6t"
+        component={EnterReceiptPage}
+        redirectUrl="/"
       />
       <Route exact path="/testpage" component={HomePage} />
       <Route exact path="/postlogout" component={PostLogoutPage} />

--- a/frontend/src/pages/index.ts
+++ b/frontend/src/pages/index.ts
@@ -3,3 +3,4 @@ export { default as PostLogoutPage } from "./PostLogoutPage";
 export { default as StatusPage } from "./StatusPage";
 export { default as Layout } from "./Layout";
 export { default as HomePage } from "./HomePage";
+export { default as EnterReceiptPage } from "./EnterReceiptPage";


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- closes #143 
- add Enter Receipt Navigation Link to header for /d6t route
- add EnterReceipt page component
- add EnterReceipt component to react-router
- add unit test

## Testing
To verify the changes proposed in this pull request…
1. Run frontend unit tests
2. Start dev environment and navigate to `/d6t`

## Screenshots
<img width="1680" alt="image" src="https://user-images.githubusercontent.com/59582489/76357134-823c9100-62ed-11ea-835c-c919c81a29eb.png">

