### PR TITLE
Bug 205 reset page on filter in status page

### DIFF
--- a/frontend/src/components/SelectFilterControls/SelectFilterControls.tsx
+++ b/frontend/src/components/SelectFilterControls/SelectFilterControls.tsx
@@ -6,7 +6,7 @@ import { faSearch } from "@fortawesome/free-solid-svg-icons";
 import classes from "./SelectFilterControls.module.scss";
 
 interface SelectFilterControls {
-  onSubmit: (filter: { option: string; value: string }) => void;
+  onSubmit: (filter: { id: string; value: string }[]) => void;
   options: Array<{ name: string; value: string }>;
   defaultOption?: string;
 }
@@ -31,10 +31,12 @@ const SelectFilterControls: React.FC<SelectFilterControls> = ({
 
   const onSubmitted: React.FormEventHandler<HTMLFormElement> = event => {
     event.preventDefault();
-    onSubmit({
-      option: currentOption,
-      value: currentValue
-    });
+    onSubmit([
+      {
+        id: currentOption,
+        value: currentValue
+      }
+    ]);
   };
 
   return (

--- a/frontend/src/components/SelectFilterControls/__tests__/selectFilterControls.spec.tsx
+++ b/frontend/src/components/SelectFilterControls/__tests__/selectFilterControls.spec.tsx
@@ -63,10 +63,12 @@ describe("SelectFilterControls component", () => {
     fireEvent.click(btn as Element);
     await wait(() => {
       expect(submitCallback).toHaveBeenCalled();
-      expect(submitCallback.mock.calls[0][0]).toMatchObject({
-        option: "testopt2",
-        value: "my search value"
-      });
+      expect(submitCallback.mock.calls[0][0]).toMatchObject([
+        {
+          id: "testopt2",
+          value: "my search value"
+        }
+      ]);
     });
   });
 });

--- a/frontend/src/pages/StatusPage/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage/StatusPage.tsx
@@ -12,14 +12,14 @@ import {
 import useDocuments from "./useDocuments";
 import createColumns from "./tableColumns";
 
+const filterAble = [
+  { name: "SDN", value: "sdn" },
+  { name: "Nomenclature", value: "nomen" },
+  { name: "Commodity", value: "commodity" }
+];
+
 const StatusPage: React.FC = () => {
-  const {
-    docs,
-    fetchDocuments,
-    setFilter,
-    filterOptions,
-    pageCount
-  } = useDocuments();
+  const { docs, fetchDocuments, pageCount } = useDocuments();
   const tableColumns = useMemo(createColumns, []);
 
   const renderSubComponent = (row: Row<Document>) => {
@@ -42,16 +42,22 @@ const StatusPage: React.FC = () => {
   const renderPagination = (table: TableInstance<Document>) => (
     <Paginator table={table} />
   );
+  const renderFilterControls = (table: TableInstance<Document>) => {
+    const { setGlobalFilter } = table;
+    return (
+      <SelectFilterControls options={filterAble} onSubmit={setGlobalFilter} />
+    );
+  };
 
   return (
     <div className="tablet:margin-x-8 overflow-x-auto">
       <Title>Status</Title>
-      <SelectFilterControls options={filterOptions} onSubmit={setFilter} />
       <Table<Document>
         columns={tableColumns}
         data={docs}
         renderSubComponent={renderSubComponent}
         renderPagination={renderPagination}
+        renderFilterControls={renderFilterControls}
         fetchData={fetchDocuments}
         pageCount={pageCount}
       />

--- a/frontend/src/pages/StatusPage/useDocuments.ts
+++ b/frontend/src/pages/StatusPage/useDocuments.ts
@@ -28,35 +28,29 @@ const useDocuments = () => {
   const { apiCall } = useAuthContext();
   const [docs, setDocs] = useState<Document[]>([]);
   const [pageCount, setPageCount] = useState<number>(9);
-  const [filter, setFilter] = useState<{ option: string; value: string }>({
-    option: "",
-    value: ""
-  });
 
-  const makeQueryString = useCallback(
-    (query: Query<Document>) => {
-      const {
-        sort: [currentSort],
-        page
-      } = query;
-      const params = new URLSearchParams();
-      if (currentSort?.id) {
-        params.set("sort", currentSort.id);
-      }
-      if (currentSort?.desc) {
-        params.set("desc", "true");
-      }
-      if (filter.value) {
-        params.set(filter.option, filter.value);
-      }
-      if (page > 1) {
-        params.set("page", page.toString());
-      }
-      const queryString = params.toString();
-      return queryString ? `?${queryString}` : "";
-    },
-    [filter]
-  );
+  const makeQueryString = useCallback((query: Query<Document>) => {
+    const {
+      sort: [currentSort],
+      page,
+      filters
+    } = query;
+    const params = new URLSearchParams();
+    if (currentSort?.id) {
+      params.set("sort", currentSort.id);
+    }
+    if (currentSort?.desc) {
+      params.set("desc", "true");
+    }
+    if (page > 1) {
+      params.set("page", page.toString());
+    }
+    filters.forEach(({ id, value }) => {
+      params.set(id, value);
+    });
+    const queryString = params.toString();
+    return queryString ? `?${queryString}` : "";
+  }, []);
 
   const fetchDocuments = useCallback(
     async (query: Query<Document>) => {
@@ -78,13 +72,7 @@ const useDocuments = () => {
   return {
     docs,
     fetchDocuments,
-    pageCount,
-    setFilter,
-    filterOptions: [
-      { name: "SDN", value: "sdn" },
-      { name: "Nomenclature", value: "nomen" },
-      { name: "Commodity", value: "commodity" }
-    ]
+    pageCount
   };
 };
 

--- a/frontend/src/solo-types/index.ts
+++ b/frontend/src/solo-types/index.ts
@@ -1,4 +1,4 @@
-import { SortingRule } from "react-table";
+import { SortingRule, Filters } from "react-table";
 export {
   default as createFakeApiDocs,
   defaultApiDoc,
@@ -93,9 +93,10 @@ export interface Document {
   receiver?: Address;
 }
 
-export interface Query<T> {
+export interface Query<T extends object> {
   sort: SortingRule<T>[];
   page: number;
+  filters: Filters<T>;
 }
 
 export interface PaginatedApiResponse<T> {

--- a/frontend/src/solo-types/react-table.d.ts
+++ b/frontend/src/solo-types/react-table.d.ts
@@ -25,10 +25,21 @@ import {
   UseSortByHooks,
   UseSortByInstanceProps,
   UseSortByOptions,
-  UseSortByState
+  UseSortByState,
+  Filters
 } from "react-table";
 
 declare module "react-table" {
+  interface TypedGlobalFiltersState<T extends object>
+    extends Omit<UseGlobalFiltersState<T>, "globalFilter"> {
+    globalFilter: Filters<T>;
+  }
+
+  interface TypedGlobalFiltersInstanceProps<T extends object>
+    extends Omit<UseGlobalFiltersInstanceProps<T>, "setGlobalFilter"> {
+    setGlobalFilter: (filters: Filters<T>) => void;
+  }
+
   export interface TableOptions<D extends object>
     extends UseExpandedOptions<D>,
       UseFiltersOptions<D>,
@@ -46,7 +57,7 @@ declare module "react-table" {
     extends UseColumnOrderInstanceProps<D>,
       UseExpandedInstanceProps<D>,
       UseFiltersInstanceProps<D>,
-      UseGlobalFiltersInstanceProps<D>,
+      TypedGlobalFiltersInstanceProps<D>,
       UsePaginationInstanceProps<D>,
       UseRowStateInstanceProps<D>,
       UseSortByInstanceProps<D> {}
@@ -55,7 +66,7 @@ declare module "react-table" {
     extends UseColumnOrderState<D>,
       UseExpandedState<D>,
       UseFiltersState<D>,
-      UseGlobalFiltersState<D>,
+      TypedGlobalFiltersState<D>,
       UsePaginationState<D>,
       UseRowStateState<D>,
       UseSortByState<D> {}


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
~~[ ] attached screenshots illustrating relevant behavior before and after my changes.~~
~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- closes #205 
- add stronger types for react-table useGlobalFilter hook
- move current filter state into react-table
- reset current page to 0 on filter change
- render globalFilters using a callback from react-table

## Testing
To verify the changes proposed in this pull request…
1. Run frontend unit tests
2. Run development environment and apply filters

## Screenshots
N/A
