### PR TITLE
Feat 194 Add table and data to enter receipt page

### DIFF
--- a/frontend/package.json
+++ b/frontend/package.json
@@ -83,6 +83,7 @@
       "src/App.tsx",
       "src/components/.*index.ts",
       "src/solo-uswds/.*index.ts",
+      "src/hooks/*.index.ts",
       "src/context/.*index.ts",
       "src/pages/.*index.ts",
       "src/components/.*fakeDoc.ts",

--- a/frontend/src/components/SdnInputForm/SdnInputForm.tsx
+++ b/frontend/src/components/SdnInputForm/SdnInputForm.tsx
@@ -1,0 +1,38 @@
+import React, { useState, useCallback } from "react";
+import { Button } from "solo-uswds";
+
+interface SdnInputFormProps {
+  onSubmit: (sdn: string) => void;
+}
+
+const SdnInputForm: React.FC<SdnInputFormProps> = ({ onSubmit }) => {
+  const [value, setValue] = useState("");
+
+  const onSubmitted: React.FormEventHandler = useCallback(
+    event => {
+      event.preventDefault();
+      onSubmit(value);
+      setValue("");
+    },
+    [onSubmit, setValue, value]
+  );
+
+  return (
+    <form
+      onSubmit={onSubmitted}
+      className="grid-row flex-row flex-justify-start flex-align-center margin-3 col-5"
+    >
+      <input
+        className="usa-input"
+        value={value}
+        onChange={e => setValue(e.currentTarget.value)}
+        placeholder="SDN"
+      />
+      <Button className="margin-top-1 margin-left-1" type="submit" square>
+        Submit
+      </Button>
+    </form>
+  );
+};
+
+export default SdnInputForm;

--- a/frontend/src/components/SdnInputForm/__tests__/sdnInputForm.spec.tsx
+++ b/frontend/src/components/SdnInputForm/__tests__/sdnInputForm.spec.tsx
@@ -1,0 +1,46 @@
+import React from "react";
+import { render, fireEvent, wait } from "test-utils";
+import SdnInputForm from "../SdnInputForm";
+
+describe("SdnInputForm component", () => {
+  const submitMock = jest.fn();
+
+  afterEach(() => {
+    submitMock.mockReset();
+  });
+
+  it("updates input value", async () => {
+    const { getByPlaceholderText } = render(
+      <SdnInputForm onSubmit={submitMock} />
+    );
+    const inputField = getByPlaceholderText("SDN");
+    fireEvent.change(inputField, {
+      target: { value: "sdniwant" }
+    });
+    await wait(() => {
+      expect(inputField).toHaveValue("sdniwant");
+    });
+  });
+
+  it("calls onSubmit callback and resets input field on form submit", async () => {
+    const { getByPlaceholderText, container } = render(
+      <SdnInputForm onSubmit={submitMock} />
+    );
+    const inputField = getByPlaceholderText("SDN");
+    const submitBtn = container.querySelector(
+      "button[type='submit']"
+    ) as Element;
+    fireEvent.change(inputField, {
+      target: { value: "anothersdn" }
+    });
+    await wait(() => {
+      expect(inputField).toHaveValue("anothersdn");
+    });
+    fireEvent.click(submitBtn);
+    await wait(() => {
+      expect(submitMock).toHaveBeenCalledTimes(1);
+      expect(submitMock.mock.calls[0][0]).toEqual("anothersdn");
+      expect(inputField).toHaveValue("");
+    });
+  });
+});

--- a/frontend/src/components/SdnInputForm/index.ts
+++ b/frontend/src/components/SdnInputForm/index.ts
@@ -1,0 +1,1 @@
+export { default } from "./SdnInputForm";

--- a/frontend/src/components/Table/Table.tsx
+++ b/frontend/src/components/Table/Table.tsx
@@ -19,8 +19,10 @@ interface TableProps<T extends object> {
   columns: Column<T>[];
   data: T[];
   initialSortBy?: SortingRule<T>[];
+  manualSortBy?: boolean;
+  manualPagination?: boolean;
   pageCount?: number;
-  fetchData: (query: Query<T>) => void;
+  fetchData?: (query: Query<T>) => void;
   renderSubComponent?: (row: Row<T>) => JSX.Element;
   renderPagination?: (table: TableInstance<T>) => JSX.Element;
   renderFilterControls?: (table: TableInstance<T>) => JSX.Element;
@@ -30,6 +32,8 @@ const Table = <T extends object>({
   columns,
   data,
   initialSortBy,
+  manualPagination = true,
+  manualSortBy = true,
   pageCount = 0,
   fetchData,
   renderSubComponent,
@@ -47,11 +51,11 @@ const Table = <T extends object>({
     {
       columns,
       data,
-      manualSortBy: true,
-      manualPagination: true,
       manualGlobalFilter: true,
       disableMultiSort: true,
-      autoResetSortBy: false,
+      manualSortBy,
+      manualPagination,
+      autoResetSortBy: !manualSortBy,
       pageCount,
       stateReducer,
       initialState: {
@@ -71,11 +75,12 @@ const Table = <T extends object>({
   } = instance;
 
   useEffect(() => {
-    fetchData({
-      sort: sortBy,
-      page: pageIndex + 1,
-      filters: globalFilter
-    });
+    fetchData &&
+      fetchData({
+        sort: sortBy,
+        page: pageIndex + 1,
+        filters: globalFilter
+      });
   }, [fetchData, sortBy, globalFilter, pageIndex]);
 
   return (

--- a/frontend/src/components/index.ts
+++ b/frontend/src/components/index.ts
@@ -6,3 +6,4 @@ export { default as DocumentDetails } from "./DocumentDetails";
 export { default as DocumentStepper } from "./DocumentStepper";
 export { default as SelectFilterControls } from "./SelectFilterControls";
 export { default as Paginator } from "./Paginator";
+export { default as SdnInputForm } from "./SdnInputForm";

--- a/frontend/src/hooks/index.ts
+++ b/frontend/src/hooks/index.ts
@@ -1,0 +1,1 @@
+export { default as useDocumentApi } from "./useDocumentApi";

--- a/frontend/src/hooks/useDocumentApi.ts
+++ b/frontend/src/hooks/useDocumentApi.ts
@@ -8,11 +8,8 @@ type DocumentApiResponse = PaginatedApiResponse<ApiDocument[]>;
 // covert api returned document to Document
 export const parseApiDocuments = (apiDocs: ApiDocument[]): Document[] =>
   apiDocs.map(apiDoc => ({
-    id: apiDoc.id,
-    sdn: apiDoc.sdn,
+    ...apiDoc,
     serviceRequest: apiDoc.service_request,
-    part: apiDoc.part,
-    statuses: apiDoc.statuses,
     suppadd: {
       ...apiDoc.suppadd
     },

--- a/frontend/src/hooks/useDocumentApi.ts
+++ b/frontend/src/hooks/useDocumentApi.ts
@@ -1,0 +1,79 @@
+import { useCallback, useState } from "react";
+import useAuthContext from "context/AuthContext";
+import { Document, ApiDocument, Query, PaginatedApiResponse } from "solo-types";
+import { createFakeApiDocs } from "solo-types";
+
+type DocumentApiResponse = PaginatedApiResponse<ApiDocument[]>;
+
+// covert api returned document to Document
+export const parseApiDocuments = (apiDocs: ApiDocument[]): Document[] =>
+  apiDocs.map(apiDoc => ({
+    id: apiDoc.id,
+    sdn: apiDoc.sdn,
+    serviceRequest: apiDoc.service_request,
+    part: apiDoc.part,
+    statuses: apiDoc.statuses,
+    suppadd: {
+      ...apiDoc.suppadd
+    },
+    shipper: apiDoc.addresses.find(
+      addy => addy.address_type.type === "Ship-To"
+    ),
+    receiver: apiDoc.addresses.find(
+      addy => addy.address_type.type === "Requester"
+    )
+  }));
+
+const useDocuments = () => {
+  const { apiCall } = useAuthContext();
+  const [pageCount, setPageCount] = useState<number>(9);
+
+  const makeQueryString = useCallback((query: Query<Document>) => {
+    const {
+      sort: [currentSort],
+      page,
+      filters
+    } = query;
+    const params = new URLSearchParams();
+    if (currentSort?.id) {
+      params.set("sort", currentSort.id);
+    }
+    if (currentSort?.desc) {
+      params.set("desc", "true");
+    }
+    if (page > 1) {
+      params.set("page", page.toString());
+    }
+    filters.forEach(({ id, value }) => {
+      params.set(id, value);
+    });
+    const queryString = params.toString();
+    return queryString ? `?${queryString}` : "";
+  }, []);
+
+  const fetchDocuments = useCallback<
+    (query: Query<Document>) => Promise<Document[]>
+  >(
+    async query => {
+      try {
+        const url = `/documents${makeQueryString(query)}`;
+        const { count, results } = await apiCall<DocumentApiResponse>(url, {
+          method: "GET"
+        });
+        setPageCount(Math.ceil(count / 25));
+        return parseApiDocuments(results);
+      } catch (e) {
+        // use fake data until api is implemented
+        return parseApiDocuments(createFakeApiDocs(25));
+      }
+    },
+    [apiCall, makeQueryString]
+  );
+
+  return {
+    fetchDocuments,
+    pageCount
+  };
+};
+
+export default useDocuments;

--- a/frontend/src/hooks/useDocumentApi.ts
+++ b/frontend/src/hooks/useDocumentApi.ts
@@ -10,9 +10,6 @@ export const parseApiDocuments = (apiDocs: ApiDocument[]): Document[] =>
   apiDocs.map(apiDoc => ({
     ...apiDoc,
     serviceRequest: apiDoc.service_request,
-    suppadd: {
-      ...apiDoc.suppadd
-    },
     shipper: apiDoc.addresses.find(
       addy => addy.address_type.type === "Ship-To"
     ),

--- a/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
+++ b/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
@@ -1,10 +1,22 @@
-import React from "react";
-import { Title } from "components";
+import React, { useMemo } from "react";
+import { Title, Table, SdnInputForm } from "components";
+import createColumns, { DocumentWithLoadingStatus } from "./tableColumns";
+import useEnterReceiptDocuments from "./useEnterReceiptDocuments";
 
 const EnterReceiptPage: React.FC = () => {
+  const { docs, addSdn } = useEnterReceiptDocuments();
+  const columns = useMemo(createColumns, []);
+
   return (
     <div className="tablet:margin-x-8 overflow-x-auto">
       <Title>Enter Receipt</Title>
+      <Table<DocumentWithLoadingStatus>
+        columns={columns}
+        data={docs}
+        manualPagination={false}
+        manualSortBy={false}
+      />
+      <SdnInputForm onSubmit={addSdn} />
     </div>
   );
 };

--- a/frontend/src/pages/EnterReceiptPage/LoadingIcon.module.scss
+++ b/frontend/src/pages/EnterReceiptPage/LoadingIcon.module.scss
@@ -1,0 +1,3 @@
+.error {
+  color: red;
+}

--- a/frontend/src/pages/EnterReceiptPage/LoadingIcon.tsx
+++ b/frontend/src/pages/EnterReceiptPage/LoadingIcon.tsx
@@ -1,0 +1,28 @@
+import React from "react";
+import classNames from "classnames";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import {
+  faSpinner,
+  faExclamationCircle,
+  faCheck
+} from "@fortawesome/free-solid-svg-icons";
+import classes from "./LoadingIcon.module.scss";
+
+interface LoadingIconProps {
+  loading: boolean;
+  error: string | null;
+}
+
+const LoadingIcon: React.FC<LoadingIconProps> = ({ loading, error }) => (
+  <span>
+    <FontAwesomeIcon
+      spin={loading}
+      icon={loading ? faSpinner : error ? faExclamationCircle : faCheck}
+      className={classNames({
+        [classes.error]: !!error
+      })}
+    />
+  </span>
+);
+
+export default LoadingIcon;

--- a/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
@@ -10,6 +10,392 @@ exports[`EnterReceiptPage Component matches snapshot 1`] = `
     >
       Enter Receipt
     </h1>
+    <table
+      class="usa-table grid-col-12 usa-table--borderless"
+      role="table"
+    >
+      <thead>
+        <tr
+          role="row"
+        >
+          <th
+            colspan="1"
+            role="columnheader"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Loading
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              SDN
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              NIIN
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Nomenclature
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Quantity
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Commodity
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Subinventory
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+          <th
+            colspan="1"
+            role="columnheader"
+            style="cursor: pointer;"
+            title="Toggle SortBy"
+          >
+            <div
+              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
+            >
+              Locator
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
+                data-icon="chevron-up"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                style="visibility: hidden;"
+                viewBox="0 0 448 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </div>
+          </th>
+        </tr>
+      </thead>
+      <tbody
+        role="rowgroup"
+      >
+        <tr
+          role="row"
+        >
+          <td
+            class="td"
+            role="cell"
+          >
+            <span>
+              <svg
+                aria-hidden="true"
+                class="svg-inline--fa fa-check fa-w-16 "
+                data-icon="check"
+                data-prefix="fas"
+                focusable="false"
+                role="img"
+                viewBox="0 0 512 512"
+                xmlns="http://www.w3.org/2000/svg"
+              >
+                <path
+                  d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+                  fill="currentColor"
+                />
+              </svg>
+            </span>
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            M3030012341234
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            5430015061999
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            TANK,LIQUID STORAGE
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            2
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            Motor Transportation
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            Subinventory
+          </td>
+          <td
+            class="td"
+            role="cell"
+          >
+            locator
+          </td>
+        </tr>
+      </tbody>
+    </table>
+    <form
+      class="grid-row flex-row flex-justify-start flex-align-center margin-3 col-5"
+    >
+      <input
+        class="usa-input"
+        placeholder="SDN"
+        value=""
+      />
+      <button
+        class="usa-button margin-top-1 margin-left-1 square"
+        type="submit"
+      >
+        Submit
+      </button>
+    </form>
   </div>
+</DocumentFragment>
+`;
+
+exports[`LoadingIcon component renders check icon on fetch success 1`] = `
+<DocumentFragment>
+  <span>
+    <svg
+      aria-hidden="true"
+      class="svg-inline--fa fa-check fa-w-16 "
+      data-icon="check"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M173.898 439.404l-166.4-166.4c-9.997-9.997-9.997-26.206 0-36.204l36.203-36.204c9.997-9.998 26.207-9.998 36.204 0L192 312.69 432.095 72.596c9.997-9.997 26.207-9.997 36.204 0l36.203 36.204c9.997 9.997 9.997 26.206 0 36.204l-294.4 294.401c-9.998 9.997-26.207 9.997-36.204-.001z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
+</DocumentFragment>
+`;
+
+exports[`LoadingIcon component renders error icon on fetch error 1`] = `
+<DocumentFragment>
+  <span>
+    <svg
+      aria-hidden="true"
+      class="svg-inline--fa fa-exclamation-circle fa-w-16 error"
+      data-icon="exclamation-circle"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M504 256c0 136.997-111.043 248-248 248S8 392.997 8 256C8 119.083 119.043 8 256 8s248 111.083 248 248zm-248 50c-25.405 0-46 20.595-46 46s20.595 46 46 46 46-20.595 46-46-20.595-46-46-46zm-43.673-165.346l7.418 136c.347 6.364 5.609 11.346 11.982 11.346h48.546c6.373 0 11.635-4.982 11.982-11.346l7.418-136c.375-6.874-5.098-12.654-11.982-12.654h-63.383c-6.884 0-12.356 5.78-11.981 12.654z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
+</DocumentFragment>
+`;
+
+exports[`LoadingIcon component renders loading icon when loading 1`] = `
+<DocumentFragment>
+  <span>
+    <svg
+      aria-hidden="true"
+      class="svg-inline--fa fa-spinner fa-w-16 fa-spin "
+      data-icon="spinner"
+      data-prefix="fas"
+      focusable="false"
+      role="img"
+      viewBox="0 0 512 512"
+      xmlns="http://www.w3.org/2000/svg"
+    >
+      <path
+        d="M304 48c0 26.51-21.49 48-48 48s-48-21.49-48-48 21.49-48 48-48 48 21.49 48 48zm-48 368c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zm208-208c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.49-48-48-48zM96 256c0-26.51-21.49-48-48-48S0 229.49 0 256s21.49 48 48 48 48-21.49 48-48zm12.922 99.078c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.491-48-48-48zm294.156 0c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48c0-26.509-21.49-48-48-48zM108.922 60.922c-26.51 0-48 21.49-48 48s21.49 48 48 48 48-21.49 48-48-21.491-48-48-48z"
+        fill="currentColor"
+      />
+    </svg>
+  </span>
 </DocumentFragment>
 `;

--- a/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPage.spec.tsx
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPage.spec.tsx
@@ -1,10 +1,136 @@
 import React from "react";
 import EnterReceiptPage from "../EnterReceiptPage";
-import { render } from "test-utils";
+import LoadingIcon from "../LoadingIcon";
+import { defaultApiResponse } from "solo-types";
+import { render, fireEvent, wait } from "test-utils";
 
 describe("EnterReceiptPage Component", () => {
-  it("matches snapshot", () => {
-    const { asFragment } = render(<EnterReceiptPage />);
+  const fetchMock = jest.fn();
+  const defaultDoc = defaultApiResponse.results[0];
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  it("matches snapshot", async () => {
+    fetchMock.mockResolvedValue(defaultApiResponse);
+    const { asFragment, queryByText, container } = render(
+      <EnterReceiptPage />,
+      {
+        authContext: {
+          apiCall: fetchMock
+        }
+      }
+    );
+    const submitBtn = container.querySelector(
+      "button[type='submit']"
+    ) as Element;
+    fireEvent.click(submitBtn);
+    await wait(() => {
+      // wait for some data to render before checking snapshot
+      expect(fetchMock).toHaveBeenCalled();
+      expect(queryByText(defaultDoc.sdn)).toBeInTheDocument();
+    });
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("calls api and adds result to table when adding an sdn", async () => {
+    fetchMock.mockResolvedValue(defaultApiResponse);
+    const { queryByText, getByPlaceholderText, container } = render(
+      <EnterReceiptPage />,
+      {
+        authContext: {
+          apiCall: fetchMock
+        }
+      }
+    );
+    const inputField = getByPlaceholderText("SDN");
+    const submit = container.querySelector("button[type='submit']") as Element;
+    fireEvent.change(inputField, {
+      target: { value: "somesdn" }
+    });
+    fireEvent.click(submit);
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(fetchMock.mock.calls[0][0]).toEqual("/documents?sdn=somesdn");
+      expect(queryByText(defaultDoc.part.nomen)).toBeInTheDocument();
+    });
+  });
+
+  it("keeps sdn in table on fetch error", async () => {
+    fetchMock.mockRejectedValue(new Error());
+    const { queryByText, getByPlaceholderText, container } = render(
+      <EnterReceiptPage />,
+      {
+        authContext: {
+          apiCall: fetchMock
+        }
+      }
+    );
+    const inputField = getByPlaceholderText("SDN");
+    const submit = container.querySelector("button[type='submit']") as Element;
+    fireEvent.change(inputField, {
+      target: { value: "badsdn" }
+    });
+    fireEvent.click(submit);
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(1);
+      expect(queryByText(defaultDoc.sdn)).toBeInTheDocument();
+    });
+  });
+
+  it("only updates associated sdn", async () => {
+    fetchMock.mockResolvedValue({
+      ...defaultApiResponse,
+      results: [{ ...defaultDoc, sdn: "1234" }]
+    });
+    const { queryByText, queryAllByText, container } = render(
+      <EnterReceiptPage />,
+      {
+        authContext: {
+          apiCall: fetchMock
+        }
+      }
+    );
+    const submit = container.querySelector("button[type='submit']") as Element;
+    fireEvent.click(submit);
+    await wait(() => {
+      expect(queryByText("1234")).toBeInTheDocument();
+    });
+    fetchMock.mockResolvedValue({
+      ...defaultApiResponse,
+      results: [
+        {
+          ...defaultDoc,
+          sdn: "6789",
+          part: { ...defaultDoc.part, nsn: "differentnsn" }
+        }
+      ]
+    });
+    fireEvent.click(submit);
+    await wait(() => {
+      expect(queryByText("1234")).toBeInTheDocument();
+      expect(queryByText("6789")).toBeInTheDocument();
+      expect(queryAllByText("differentnsn")).toHaveLength(1);
+    });
+  });
+});
+
+describe("LoadingIcon component", () => {
+  it("renders loading icon when loading", async () => {
+    const { asFragment } = render(<LoadingIcon loading error={null} />);
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders error icon on fetch error", async () => {
+    const { asFragment } = render(
+      <LoadingIcon loading={false} error={"some error"} />
+    );
+    expect(asFragment()).toMatchSnapshot();
+  });
+
+  it("renders check icon on fetch success", async () => {
+    const { asFragment } = render(<LoadingIcon loading={false} error={null} />);
     expect(asFragment()).toMatchSnapshot();
   });
 });

--- a/frontend/src/pages/EnterReceiptPage/tableColumns.tsx
+++ b/frontend/src/pages/EnterReceiptPage/tableColumns.tsx
@@ -1,0 +1,59 @@
+import React from "react";
+import { Column } from "react-table";
+import { Document } from "solo-types";
+import LoadingIcon from "./LoadingIcon";
+
+export interface DocumentWithLoadingStatus extends Partial<Document> {
+  loading: boolean;
+  error: string | null;
+}
+
+type CreateColumns = () => Column<DocumentWithLoadingStatus>[];
+
+const createColumns: CreateColumns = () => [
+  {
+    Header: "Loading",
+    Cell: ({
+      row: {
+        original: { loading, error }
+      }
+    }) => <LoadingIcon loading={loading} error={error} />
+  },
+  {
+    Header: "SDN",
+    accessor: "sdn"
+  },
+  {
+    Header: "NIIN",
+    accessor: "part.nsn",
+    id: "niin"
+  },
+  {
+    Header: "Nomenclature",
+    id: "nomen",
+    accessor: "part.nomen"
+  },
+  {
+    Header: "Quantity",
+    id: "quantity",
+    accessor: ({ statuses = [] }) =>
+      statuses[statuses.length - 1]?.projected_qty
+  },
+  {
+    Header: "Commodity",
+    id: "commodity",
+    accessor: "suppadd.desc"
+  },
+  {
+    Header: "Subinventory",
+    id: "subinventory",
+    accessor: () => "Subinventory"
+  },
+  {
+    Header: "Locator",
+    id: "locator",
+    accessor: () => "locator"
+  }
+];
+
+export default createColumns;

--- a/frontend/src/pages/EnterReceiptPage/useEnterReceiptDocuments.ts
+++ b/frontend/src/pages/EnterReceiptPage/useEnterReceiptDocuments.ts
@@ -1,0 +1,58 @@
+import { useCallback, useState } from "react";
+import { useDocumentApi } from "hooks";
+import { DocumentWithLoadingStatus } from "./tableColumns";
+
+const useDocuments = () => {
+  const { fetchDocuments, ...rest } = useDocumentApi();
+  const [docs, setDocs] = useState<DocumentWithLoadingStatus[]>([]);
+
+  const updateDoc = useCallback(
+    (sdn: string, data: Partial<DocumentWithLoadingStatus>) => {
+      setDocs(prevDocs =>
+        prevDocs.map(existingDoc =>
+          existingDoc.sdn === sdn ? { ...existingDoc, ...data } : existingDoc
+        )
+      );
+    },
+    [setDocs]
+  );
+
+  const fetchDetailsForDocument = useCallback(
+    async (sdn: string) => {
+      try {
+        const [doc] = await fetchDocuments({
+          filters: [{ id: "sdn", value: sdn }],
+          sort: [],
+          page: 0
+        });
+        updateDoc(sdn, {
+          ...doc,
+          loading: false,
+          error: null
+        });
+      } catch (e) {
+        /* istanbul ignore next */
+        updateDoc(sdn, {
+          loading: false,
+          error: e.toString()
+        });
+      }
+    },
+    [fetchDocuments, updateDoc]
+  );
+
+  const addSdn = (sdn: string) => {
+    setDocs(prevDocs => [...prevDocs, { sdn, loading: true, error: null }]);
+    setTimeout(() => {
+      fetchDetailsForDocument(sdn);
+    }, Math.floor(Math.random() * 1000)); // add up to 1 second of load time
+  };
+
+  return {
+    docs,
+    addSdn,
+    ...rest
+  };
+};
+
+export default useDocuments;

--- a/frontend/src/pages/StatusPage/StatusPage.tsx
+++ b/frontend/src/pages/StatusPage/StatusPage.tsx
@@ -19,7 +19,7 @@ const filterAble = [
 ];
 
 const StatusPage: React.FC = () => {
-  const { docs, fetchDocuments, pageCount } = useDocuments();
+  const { docs, updateDocuments, pageCount } = useDocuments();
   const tableColumns = useMemo(createColumns, []);
 
   const renderSubComponent = (row: Row<Document>) => {
@@ -58,7 +58,7 @@ const StatusPage: React.FC = () => {
         renderSubComponent={renderSubComponent}
         renderPagination={renderPagination}
         renderFilterControls={renderFilterControls}
-        fetchData={fetchDocuments}
+        fetchData={updateDocuments}
         pageCount={pageCount}
       />
     </div>

--- a/frontend/src/pages/StatusPage/useDocuments.ts
+++ b/frontend/src/pages/StatusPage/useDocuments.ts
@@ -1,78 +1,23 @@
 import { useCallback, useState } from "react";
-import useAuthContext from "context/AuthContext";
-import { Document, ApiDocument, Query, PaginatedApiResponse } from "solo-types";
-import { createFakeApiDocs } from "solo-types";
-
-type DocumentApiResponse = PaginatedApiResponse<ApiDocument[]>;
-
-// covert api returned document to Document
-export const parseApiDocuments = (apiDocs: ApiDocument[]): Document[] =>
-  apiDocs.map(apiDoc => ({
-    id: apiDoc.id,
-    sdn: apiDoc.sdn,
-    serviceRequest: apiDoc.service_request,
-    part: apiDoc.part,
-    statuses: apiDoc.statuses,
-    suppadd: {
-      ...apiDoc.suppadd
-    },
-    shipper: apiDoc.addresses.find(
-      addy => addy.address_type.type === "Ship-To"
-    ),
-    receiver: apiDoc.addresses.find(
-      addy => addy.address_type.type === "Requester"
-    )
-  }));
+import { Document, Query } from "solo-types";
+import { useDocumentApi } from "hooks";
 
 const useDocuments = () => {
-  const { apiCall } = useAuthContext();
+  const { fetchDocuments, ...rest } = useDocumentApi();
   const [docs, setDocs] = useState<Document[]>([]);
-  const [pageCount, setPageCount] = useState<number>(9);
 
-  const makeQueryString = useCallback((query: Query<Document>) => {
-    const {
-      sort: [currentSort],
-      page,
-      filters
-    } = query;
-    const params = new URLSearchParams();
-    if (currentSort?.id) {
-      params.set("sort", currentSort.id);
-    }
-    if (currentSort?.desc) {
-      params.set("desc", "true");
-    }
-    if (page > 1) {
-      params.set("page", page.toString());
-    }
-    filters.forEach(({ id, value }) => {
-      params.set(id, value);
-    });
-    const queryString = params.toString();
-    return queryString ? `?${queryString}` : "";
-  }, []);
-
-  const fetchDocuments = useCallback(
+  const updateDocuments = useCallback(
     async (query: Query<Document>) => {
-      try {
-        const url = `/documents${makeQueryString(query)}`;
-        const { count, results } = await apiCall<DocumentApiResponse>(url, {
-          method: "GET"
-        });
-        setPageCount(Math.ceil(count / 25));
-        setDocs(parseApiDocuments(results));
-      } catch (e) {
-        // use fake data until api is implemented
-        setDocs(parseApiDocuments(createFakeApiDocs(25)));
-      }
+      const docs = await fetchDocuments(query);
+      setDocs(docs);
     },
-    [setDocs, apiCall, makeQueryString]
+    [fetchDocuments]
   );
 
   return {
     docs,
-    fetchDocuments,
-    pageCount
+    updateDocuments,
+    ...rest
   };
 };
 


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- closes #193 
- closes #194 
- closes #144 
- closes #196 
- generalize useDocuments hook from status page to a more generic useDocumentApi hook
- add SdnInputForm to enter receipts page
- add table to enter receipts page
- load sdn data asynchronously on form submission
- add loading icon to indicate success/failure of data loading

## Testing
To verify the changes proposed in this pull request…
1. Run unit tests
2. View d6t page in development environment

## Screenshots
<img width="1662" alt="Screen Shot 2020-03-13 at 1 55 05 PM" src="https://user-images.githubusercontent.com/59582489/76647071-7988cc80-6532-11ea-928d-1318250fbb74.png">
<img width="1654" alt="Screen Shot 2020-03-13 at 1 55 35 PM" src="https://user-images.githubusercontent.com/59582489/76647079-7c83bd00-6532-11ea-9037-10b28b7206ce.png">
<img width="1643" alt="Screen Shot 2020-03-13 at 1 56 06 PM" src="https://user-images.githubusercontent.com/59582489/76647088-7ee61700-6532-11ea-956c-0f6bee49d10c.png">
<img width="1655" alt="Screen Shot 2020-03-13 at 1 56 19 PM" src="https://user-images.githubusercontent.com/59582489/76647092-81487100-6532-11ea-8555-a5c25f4f2fe6.png">

