### PR TITLE
Feat 198 add received by form and submit functionality to COR page

### DIFF
--- a/frontend/src/hooks/useDocumentSet.ts
+++ b/frontend/src/hooks/useDocumentSet.ts
@@ -2,22 +2,50 @@ import { useCallback, useState } from "react";
 import { Document, Query } from "solo-types";
 import { useDocumentApi } from "hooks";
 
-const useDocumentSet = () => {
+const useDocumentSet = <T extends Partial<Document> = Document>() => {
   const { fetchDocuments, ...rest } = useDocumentApi();
-  const [docs, setDocs] = useState<Document[]>([]);
+  const [docs, setDocs] = useState<T[]>([]);
 
   const updateDocuments = useCallback(
     async (query: Query<Document>) => {
       const docs = await fetchDocuments(query);
-      setDocs(docs);
+      setDocs(docs as T[]);
     },
     [fetchDocuments, setDocs]
   );
+
+  const modifyDocument = useCallback(
+    (sdn: string, data: Partial<T>) => {
+      setDocs(prevDocs =>
+        prevDocs.map(doc => (doc.sdn === sdn ? { ...doc, ...data } : doc))
+      );
+    },
+    [setDocs]
+  );
+
+  const removeDocument = useCallback(
+    (sdn: string) => {
+      setDocs(prevDocs => prevDocs.filter(doc => doc.sdn !== sdn));
+    },
+    [setDocs]
+  );
+
+  const addDocument = useCallback((sdn: string, data: Partial<T>) => {
+    setDocs(prevDocs => [...prevDocs, ({ sdn, ...data } as unknown) as T]);
+    // fetchDetailsForDocument(sdn);
+  }, []);
+
+  const clearAllDocuments = useCallback(() => setDocs([]), [setDocs]);
 
   return {
     docs,
     setDocs,
     updateDocuments,
+    modifyDocument,
+    removeDocument,
+    addDocument,
+    clearAllDocuments,
+    fetchDocuments,
     ...rest
   };
 };

--- a/frontend/src/pages/ConfirmationOfReceiptPage/ConfirmationOfReceiptPage.tsx
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/ConfirmationOfReceiptPage.tsx
@@ -12,8 +12,14 @@ const filterable = [
 ];
 
 const ConfirmationOfReceiptPage: React.FC = () => {
-  const { docs, updateDocuments, pageCount } = useCORDocuments();
-  const columns = useMemo(createColumns, []);
+  const { docs, updateDocuments, pageCount, submitCOR } = useCORDocuments();
+  const columns = useMemo(
+    () =>
+      createColumns({
+        onSubmitCOR: submitCOR
+      }),
+    [submitCOR]
+  );
 
   const renderPagination = (table: TableInstance<Document>) => (
     <Paginator table={table} />

--- a/frontend/src/pages/ConfirmationOfReceiptPage/ReceivedByInput.module.scss
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/ReceivedByInput.module.scss
@@ -1,0 +1,9 @@
+.receivedByInput {
+  margin-top: 0 !important;
+}
+
+.btn {
+  margin-left: 8px;
+  width: 100px !important;
+  flex-shrink: 0;
+}

--- a/frontend/src/pages/ConfirmationOfReceiptPage/ReceivedByInput.tsx
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/ReceivedByInput.tsx
@@ -1,0 +1,56 @@
+import React, { useState, useEffect } from "react";
+import classNames from "classnames";
+import { Row, Cell } from "react-table";
+import { Button } from "solo-uswds";
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome";
+import { faSpinner } from "@fortawesome/free-solid-svg-icons";
+import { DocumentWithReceivedBy } from "./tableColumns";
+import classes from "./ReceivedByInput.module.scss";
+
+interface ReceivedByInputCellProps {
+  onSubmitCOR: (sdn: string, receivedBy: string) => void;
+  cell: Cell<DocumentWithReceivedBy>;
+  row: Row<DocumentWithReceivedBy>;
+}
+
+const ReceivedByInputCell: React.FC<ReceivedByInputCellProps> = ({
+  onSubmitCOR,
+  row: {
+    original: { sdn, submitting, error }
+  }
+}) => {
+  const [receivedBy, setReceivedBy] = useState("");
+  const onSubmit: React.FormEventHandler<HTMLFormElement> = e => {
+    e.preventDefault();
+    onSubmitCOR(sdn, receivedBy);
+  };
+
+  useEffect(() => {
+    setReceivedBy("");
+  }, [sdn]);
+
+  return (
+    <form
+      onSubmit={onSubmit}
+      className="display-flex flex-row flex-justify-start flex-align-center"
+    >
+      <input
+        className={classNames("usa-input", classes.receivedByInput)}
+        placeholder="Rank Lastname, Firstname MI"
+        disabled={submitting}
+        value={receivedBy}
+        onChange={e => setReceivedBy(e.currentTarget.value)}
+      />
+      <Button
+        type="submit"
+        disabled={submitting || !receivedBy}
+        color={error ? "secondary" : undefined}
+        className={classes.btn}
+      >
+        {submitting ? <FontAwesomeIcon icon={faSpinner} spin /> : "Submit"}
+      </Button>
+    </form>
+  );
+};
+
+export default ReceivedByInputCell;

--- a/frontend/src/pages/ConfirmationOfReceiptPage/__tests__/__snapshots__/confirmationOfReceiptPage.spec.tsx.snap
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/__tests__/__snapshots__/confirmationOfReceiptPage.spec.tsx.snap
@@ -202,33 +202,7 @@ exports[`ConfirmationOfReceiptPage Component matches snapshot 1`] = `
             <div
               class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
             >
-              Received By
-              <svg
-                aria-hidden="true"
-                class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
-                data-icon="chevron-up"
-                data-prefix="fas"
-                focusable="false"
-                role="img"
-                style="visibility: hidden;"
-                viewBox="0 0 448 512"
-                xmlns="http://www.w3.org/2000/svg"
-              >
-                <path
-                  d="M240.971 130.524l194.343 194.343c9.373 9.373 9.373 24.569 0 33.941l-22.667 22.667c-9.357 9.357-24.522 9.375-33.901.04L224 227.495 69.255 381.516c-9.379 9.335-24.544 9.317-33.901-.04l-22.667-22.667c-9.373-9.373-9.373-24.569 0-33.941L207.03 130.525c9.372-9.373 24.568-9.373 33.941-.001z"
-                  fill="currentColor"
-                />
-              </svg>
-            </div>
-          </th>
-          <th
-            colspan="1"
-            role="columnheader"
-          >
-            <div
-              class="display-flex flex-justify flex-align-center flex-no-wrap text-no-wrap"
-            >
-              Submit
+              Submit COR
               <svg
                 aria-hidden="true"
                 class="svg-inline--fa fa-chevron-up fa-w-14 margin-left-05"
@@ -281,17 +255,22 @@ exports[`ConfirmationOfReceiptPage Component matches snapshot 1`] = `
             class="td"
             role="cell"
           >
-            Received By
-          </td>
-          <td
-            class="td"
-            role="cell"
-          >
-            <button
-              class="usa-button"
+            <form
+              class="display-flex flex-row flex-justify-start flex-align-center"
             >
-              Submit
-            </button>
+              <input
+                class="usa-input receivedByInput"
+                placeholder="Rank Lastname, Firstname MI"
+                value=""
+              />
+              <button
+                class="usa-button btn"
+                disabled=""
+                type="submit"
+              >
+                Submit
+              </button>
+            </form>
           </td>
         </tr>
       </tbody>

--- a/frontend/src/pages/ConfirmationOfReceiptPage/__tests__/submitCOR.spec.tsx
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/__tests__/submitCOR.spec.tsx
@@ -1,0 +1,123 @@
+import React from "react";
+import { defaultApiResponse } from "solo-types";
+import { render, fireEvent, wait } from "test-utils";
+import ConfirmationOfReceiptPage from "../ConfirmationOfReceiptPage";
+
+jest.mock("components/Paginator", () => () => <div>paginator</div>);
+jest.mock("components/SelectFilterControls", () => () => <div>filters</div>);
+jest.mock("components/Title", () => () => <div>title</div>);
+
+afterAll(() => {
+  jest.restoreAllMocks();
+});
+
+describe("ConfirmationOfReceiptPage component submit COR functionality", () => {
+  const fetchMock = jest.fn();
+  const defaultDoc = defaultApiResponse.results[0];
+
+  afterEach(() => {
+    fetchMock.mockReset();
+  });
+
+  const renderWithInitialData = async () => {
+    fetchMock.mockResolvedValue(defaultApiResponse);
+    const { queryByText, getByPlaceholderText, container, ...rest } = render(
+      <ConfirmationOfReceiptPage />,
+      {
+        authContext: {
+          apiCall: fetchMock
+        }
+      }
+    );
+    await wait(() => {
+      expect(queryByText(defaultDoc.sdn)).toBeInTheDocument();
+    });
+    const receivedByInput = getByPlaceholderText("Rank Lastname, Firstname MI");
+    fireEvent.change(receivedByInput, {
+      target: { value: "Private Casarotto, Stuart" }
+    });
+    await wait(() => {
+      expect(receivedByInput).toHaveValue("Private Casarotto, Stuart");
+    });
+    const submitBtn = container.querySelector(
+      "button[type='submit']"
+    ) as Element;
+    return {
+      queryByText,
+      getByPlaceholderText,
+      container,
+      submitBtn,
+      receivedByInput,
+      ...rest
+    };
+  };
+
+  it("form inputs are disabled when appropriate", async () => {
+    const { submitBtn, receivedByInput } = await renderWithInitialData();
+    expect(submitBtn).not.toHaveAttribute("disabled");
+    expect(receivedByInput).not.toHaveAttribute("disabled");
+    fireEvent.change(receivedByInput, {
+      target: { value: "" }
+    });
+    await wait(() => {
+      expect(submitBtn).toHaveAttribute("disabled");
+    });
+    fireEvent.change(receivedByInput, {
+      target: { value: "LCpl Haley, Garrett" }
+    });
+    await wait(() => {
+      expect(submitBtn).not.toHaveAttribute("disabled");
+    });
+  });
+
+  it("submits COR to api on form submission in table row", async () => {
+    const { submitBtn, queryByText } = await renderWithInitialData();
+    fetchMock.mockResolvedValue({});
+    fireEvent.click(submitBtn);
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(fetchMock.mock.calls[1][0]).toEqual("/document/cor");
+      expect(fetchMock.mock.calls[1][1]).toMatchObject({
+        method: "POST",
+        body: JSON.stringify({
+          sdn: defaultDoc.sdn,
+          status: "COR",
+          receivedBy: "Private Casarotto, Stuart"
+        })
+      });
+      expect(queryByText("Private Casarotto, Stuart")).not.toBeInTheDocument();
+      expect(queryByText(defaultDoc.sdn)).not.toBeInTheDocument();
+    });
+  });
+
+  it("leaves row and input in table with original value on api/network error", async () => {
+    const {
+      queryByText,
+      submitBtn,
+      receivedByInput
+    } = await renderWithInitialData();
+    fetchMock.mockRejectedValue(new Error("some error"));
+    fireEvent.click(submitBtn);
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(queryByText(defaultDoc.sdn)).toBeInTheDocument();
+      expect(receivedByInput).toHaveValue("Private Casarotto, Stuart");
+    });
+  });
+
+  it("leaves row and input in table with original value on api/network error default message", async () => {
+    const {
+      queryByText,
+      submitBtn,
+      receivedByInput
+    } = await renderWithInitialData();
+    const err = new Error("");
+    fetchMock.mockRejectedValue(err);
+    fireEvent.click(submitBtn);
+    await wait(() => {
+      expect(fetchMock).toHaveBeenCalledTimes(2);
+      expect(queryByText(defaultDoc.sdn)).toBeInTheDocument();
+      expect(receivedByInput).toHaveValue("Private Casarotto, Stuart");
+    });
+  });
+});

--- a/frontend/src/pages/ConfirmationOfReceiptPage/tableColumns.tsx
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/tableColumns.tsx
@@ -1,11 +1,21 @@
 import React from "react";
 import { Column } from "react-table";
 import { Document } from "solo-types";
-import { Button } from "solo-uswds";
+import ReceivedByInputCell from "./ReceivedByInput";
 
-type CreateColumns = () => Column<Document>[];
+export interface DocumentWithReceivedBy extends Document {
+  receivedBy?: string;
+  submitting?: boolean;
+  error?: string | null;
+}
 
-const createColumns: CreateColumns = () => [
+interface CreateOptions {
+  onSubmitCOR: (sdn: string, receivedBy: string) => void;
+}
+
+type CreateColumns = (opts: CreateOptions) => Column<DocumentWithReceivedBy>[];
+
+const createColumns: CreateColumns = ({ onSubmitCOR }) => [
   {
     Header: "SDN",
     accessor: "sdn"
@@ -26,14 +36,12 @@ const createColumns: CreateColumns = () => [
     accessor: "suppadd.desc"
   },
   {
-    Header: "Received By",
+    Header: "Submit COR",
     id: "receivedBy",
-    accessor: () => "Received By"
-  },
-  {
-    Header: "Submit",
-    id: "submit",
-    Cell: () => <Button onClick={() => {}}>Submit</Button>
+    accessor: "receivedBy",
+    Cell: ({ ...args }) => (
+      <ReceivedByInputCell {...args} onSubmitCOR={onSubmitCOR} />
+    )
   }
 ];
 

--- a/frontend/src/pages/ConfirmationOfReceiptPage/useCORDocuments.ts
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/useCORDocuments.ts
@@ -1,9 +1,20 @@
 import { useCallback } from "react";
 import { useDocumentSet } from "hooks";
 import { Query, Document } from "solo-types";
+import { DocumentWithReceivedBy } from "./tableColumns";
+import { useAuthContext } from "context";
+import { sleep } from "test-utils";
 
 const useCORDocuments = () => {
-  const { setDocs, updateDocuments, ...rest } = useDocumentSet();
+  const { apiCall } = useAuthContext();
+  const {
+    setDocs,
+    docs,
+    updateDocuments,
+    modifyDocument,
+    removeDocument,
+    ...rest
+  } = useDocumentSet<DocumentWithReceivedBy>();
 
   const updateDocumentsWithD6TStatus = useCallback(
     (query: Query<Document>) =>
@@ -21,9 +32,40 @@ const useCORDocuments = () => {
     [updateDocuments]
   );
 
+  const submitCOR = useCallback(
+    async (sdn: string, receivedBy: string) => {
+      modifyDocument(sdn, {
+        submitting: true
+      });
+      // simulate up to 1.5 seconds of load time
+      await sleep(Math.floor(Math.random() * 1500));
+      try {
+        // submit document and remove from current list
+        await apiCall("/document/cor", {
+          method: "POST",
+          body: JSON.stringify({
+            sdn: sdn,
+            status: "COR",
+            receivedBy: receivedBy
+          })
+        });
+        removeDocument(sdn);
+      } catch (e) {
+        // api or network error
+        modifyDocument(sdn, {
+          submitting: false,
+          error: e.message || "Something went wrong"
+        });
+      }
+    },
+    [modifyDocument, removeDocument, apiCall]
+  );
+
   return {
     setDocs,
+    docs,
     updateDocuments: updateDocumentsWithD6TStatus,
+    submitCOR,
     ...rest
   };
 };

--- a/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPage.spec.tsx
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPage.spec.tsx
@@ -73,7 +73,7 @@ describe("EnterReceiptPage Component", () => {
     fireEvent.click(submit);
     await wait(() => {
       expect(fetchMock).toHaveBeenCalledTimes(1);
-      expect(queryByText(defaultDoc.sdn)).toBeInTheDocument();
+      expect(queryByText(/^M30300/)).toBeInTheDocument();
     });
   });
 

--- a/frontend/src/solo-types/apiDoc.ts
+++ b/frontend/src/solo-types/apiDoc.ts
@@ -266,7 +266,8 @@ const createFakeApiDocuments = (count: number = 20): ApiDocument[] => {
     addresses: defaultApiDoc.addresses.map(addy => ({
       ...addy,
       name: faker.company.companyName()
-    }))
+    })),
+    sdn: `M30300${faker.finance.account(8)}`
   }));
 };
 


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- closes #198 
- closes  #199
- generalize useDocumentSet hook for use in both EnterReceiptPage and ConfirmationOfReceiptPage
- add received by form component with input field and submit button
- add form to table in COR page
- disable form elements where appropriate
- submit COR to api on form submission

## Testing
To verify the changes proposed in this pull request…
1. Run frontend unit tests
2. Submit COR in development environment

## Screenshots
<img width="1570" alt="Screen Shot 2020-03-17 at 12 54 04 PM" src="https://user-images.githubusercontent.com/59582489/76880821-9da81e80-684e-11ea-8113-19ddaa6cb769.png">
<img width="1560" alt="Screen Shot 2020-03-17 at 12 55 24 PM" src="https://user-images.githubusercontent.com/59582489/76880825-9ed94b80-684e-11ea-82d9-b3e2fa320293.png">

