### PR TITLE
implement automatic token refreshing for jwts in frontend

### DIFF
--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -46,6 +46,10 @@ REST_FRAMEWORK = {
     "ORDERING_PARAM": "sort",
 }
 
+SIMPLE_JWT = {
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.SlidingToken",),
+}
+
 # setup the domain to serve from based on environment
 API_DOMAIN = os.environ.get("API_DOMAIN")
 AUTH_DOMAIN = os.environ.get("AUTH_DOMAIN")

--- a/backend/app/settings.py
+++ b/backend/app/settings.py
@@ -47,7 +47,7 @@ REST_FRAMEWORK = {
 }
 
 SIMPLE_JWT = {
-    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.SlidingToken",),
+    "ROTATE_REFRESH_TOKENS": True,
 }
 
 # setup the domain to serve from based on environment

--- a/backend/solo_rog_api/serializers.py
+++ b/backend/solo_rog_api/serializers.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Optional, cast
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import AbstractUser
 from rest_framework import serializers, exceptions
-from rest_framework_simplejwt.tokens import SlidingToken
+from rest_framework_simplejwt.tokens import RefreshToken
 from .models import (
     AddressType,
     Dic,
@@ -24,9 +24,9 @@ class TokenObtainSerializer(serializers.Serializer):
         )
         if user is None or not user.is_active:
             raise exceptions.AuthenticationFailed()
-        token = SlidingToken.for_user(user)
-        token["username"] = user.username
-        return {"token": str(token)}
+        refresh = RefreshToken.for_user(user)
+        refresh["username"] = user.username
+        return {"refresh": str(refresh), "access": str(refresh.access_token)}
 
 
 class LocatorSerializer(serializers.ModelSerializer):

--- a/backend/solo_rog_api/serializers.py
+++ b/backend/solo_rog_api/serializers.py
@@ -2,7 +2,7 @@ from typing import Dict, Any, Optional, cast
 from django.contrib.auth import authenticate
 from django.contrib.auth.models import AbstractUser
 from rest_framework import serializers, exceptions
-from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.tokens import SlidingToken
 from .models import (
     AddressType,
     Dic,
@@ -24,9 +24,9 @@ class TokenObtainSerializer(serializers.Serializer):
         )
         if user is None or not user.is_active:
             raise exceptions.AuthenticationFailed()
-        refresh = RefreshToken.for_user(user)
-        refresh["username"] = user.username
-        return {"refresh": str(refresh), "access": str(refresh.access_token)}
+        token = SlidingToken.for_user(user)
+        token["username"] = user.username
+        return {"token": str(token)}
 
 
 class LocatorSerializer(serializers.ModelSerializer):

--- a/backend/solo_rog_api/test/test_serializers.py
+++ b/backend/solo_rog_api/test/test_serializers.py
@@ -52,15 +52,14 @@ class TokenObtainSerializerTestCase(TestCase):
         serializer = TokenObtainSerializer(data={})
         self.assertTrue(serializer.is_valid())
         self.assertTrue(auth_mock.called)
-        self.assertIn("refresh", serializer.validated_data)
-        self.assertIn("access", serializer.validated_data)
+        self.assertIn("token", serializer.validated_data)
 
     def test_token_contains_username_and_id(self, auth_mock: Mock) -> None:
         auth_mock.return_value = self.user
         serializer = TokenObtainSerializer(data={})
         self.assertTrue(serializer.is_valid())
-        self.assertIn("access", serializer.validated_data)
-        access_token = serializer.validated_data.get("access")
+        self.assertIn("token", serializer.validated_data)
+        access_token = serializer.validated_data.get("token")
         data = jwt.decode(access_token, verify=False)
         self.assertDictContainsSubset(
             {"username": self.user.username, "user_id": self.user.id}, data
@@ -70,7 +69,7 @@ class TokenObtainSerializerTestCase(TestCase):
         auth_mock.return_value = self.user
         serializer = TokenObtainSerializer(data={})
         self.assertTrue(serializer.is_valid())
-        access_token = serializer.validated_data.get("access")
+        access_token = serializer.validated_data.get("token")
         jwt.decode(access_token, settings.SECRET_KEY, verify=True)
         with self.assertRaises(InvalidSignatureError):
             jwt.decode(access_token, "not secret key", verify=True)

--- a/backend/solo_rog_api/test/test_serializers.py
+++ b/backend/solo_rog_api/test/test_serializers.py
@@ -52,14 +52,15 @@ class TokenObtainSerializerTestCase(TestCase):
         serializer = TokenObtainSerializer(data={})
         self.assertTrue(serializer.is_valid())
         self.assertTrue(auth_mock.called)
-        self.assertIn("token", serializer.validated_data)
+        self.assertIn("access", serializer.validated_data)
+        self.assertIn("refresh", serializer.validated_data)
 
     def test_token_contains_username_and_id(self, auth_mock: Mock) -> None:
         auth_mock.return_value = self.user
         serializer = TokenObtainSerializer(data={})
         self.assertTrue(serializer.is_valid())
-        self.assertIn("token", serializer.validated_data)
-        access_token = serializer.validated_data.get("token")
+        self.assertIn("access", serializer.validated_data)
+        access_token = serializer.validated_data.get("access")
         data = jwt.decode(access_token, verify=False)
         self.assertDictContainsSubset(
             {"username": self.user.username, "user_id": self.user.id}, data
@@ -69,7 +70,7 @@ class TokenObtainSerializerTestCase(TestCase):
         auth_mock.return_value = self.user
         serializer = TokenObtainSerializer(data={})
         self.assertTrue(serializer.is_valid())
-        access_token = serializer.validated_data.get("token")
+        access_token = serializer.validated_data.get("access")
         jwt.decode(access_token, settings.SECRET_KEY, verify=True)
         with self.assertRaises(InvalidSignatureError):
             jwt.decode(access_token, "not secret key", verify=True)

--- a/backend/solo_rog_api/test/test_views.py
+++ b/backend/solo_rog_api/test/test_views.py
@@ -21,7 +21,7 @@ class ObtainTokenViewTestCase(APITestCase):
         auth_mock.return_value = self.user
         response = self.client.post(reverse("login"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn("token", response.json())
+        self.assertIn("access", response.json())
 
     def test_unauthenticated_user_cannot_retrieve_tokens(self, auth_mock: Mock) -> None:
         auth_mock.side_effect = AuthenticationFailed()

--- a/backend/solo_rog_api/test/test_views.py
+++ b/backend/solo_rog_api/test/test_views.py
@@ -21,8 +21,7 @@ class ObtainTokenViewTestCase(APITestCase):
         auth_mock.return_value = self.user
         response = self.client.post(reverse("login"))
         self.assertEqual(response.status_code, 200)
-        self.assertIn("access", response.json())
-        self.assertIn("refresh", response.json())
+        self.assertIn("token", response.json())
 
     def test_unauthenticated_user_cannot_retrieve_tokens(self, auth_mock: Mock) -> None:
         auth_mock.side_effect = AuthenticationFailed()

--- a/backend/solo_rog_api/urls.py
+++ b/backend/solo_rog_api/urls.py
@@ -1,8 +1,10 @@
 from django.urls import path
+from rest_framework_simplejwt.views import TokenRefreshSlidingView
 from . import views
 
 urlpatterns = [
     path("login/", views.ObtainTokenView.as_view(), name="login"),
+    path("login/refresh/", TokenRefreshSlidingView.as_view(), name="login_refresh"),
     path("workerlog/", views.CeleryDebugTaskView.as_view(), name="workerlog"),
     path("document/", views.DocumentList.as_view(), name="document_list"),
 ]

--- a/backend/solo_rog_api/urls.py
+++ b/backend/solo_rog_api/urls.py
@@ -1,10 +1,10 @@
 from django.urls import path
-from rest_framework_simplejwt.views import TokenRefreshSlidingView
+from rest_framework_simplejwt.views import TokenRefreshView
 from . import views
 
 urlpatterns = [
     path("login/", views.ObtainTokenView.as_view(), name="login"),
-    path("login/refresh/", TokenRefreshSlidingView.as_view(), name="login_refresh"),
+    path("login/refresh/", TokenRefreshView.as_view(), name="login_refresh"),
     path("workerlog/", views.CeleryDebugTaskView.as_view(), name="workerlog"),
     path("document/", views.DocumentList.as_view(), name="document_list"),
 ]

--- a/backend/solo_rog_api/views.py
+++ b/backend/solo_rog_api/views.py
@@ -4,7 +4,8 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework.permissions import IsAuthenticated
-from rest_framework_simplejwt.views import TokenObtainPairView
+from rest_framework_simplejwt.views import TokenObtainSlidingView
+
 from django_filters import rest_framework as filters
 from .models import Document
 from .serializers import TokenObtainSerializer, DocumentSerializer
@@ -24,7 +25,7 @@ class CeleryDebugTaskView(generics.CreateAPIView):
         return Response({"task_id": task.id}, status=status.HTTP_200_OK)
 
 
-class ObtainTokenView(TokenObtainPairView):
+class ObtainTokenView(TokenObtainSlidingView):
     serializer_class = TokenObtainSerializer
 
 

--- a/backend/solo_rog_api/views.py
+++ b/backend/solo_rog_api/views.py
@@ -4,7 +4,7 @@ from rest_framework.filters import OrderingFilter
 from rest_framework.response import Response
 from rest_framework.request import Request
 from rest_framework.permissions import IsAuthenticated
-from rest_framework_simplejwt.views import TokenObtainSlidingView
+from rest_framework_simplejwt.views import TokenObtainPairView
 
 from django_filters import rest_framework as filters
 from .models import Document
@@ -25,7 +25,7 @@ class CeleryDebugTaskView(generics.CreateAPIView):
         return Response({"task_id": task.id}, status=status.HTTP_200_OK)
 
 
-class ObtainTokenView(TokenObtainSlidingView):
+class ObtainTokenView(TokenObtainPairView):
     serializer_class = TokenObtainSerializer
 
 

--- a/frontend/src/const.ts
+++ b/frontend/src/const.ts
@@ -1,10 +1,14 @@
-export const TOKEN_LOCAL_STORAGE_KEY = "solo.token";
+export const ACCESS_TOKEN_LOCAL_STORAGE_KEY = "solo.accessToken";
+
+export const REFRESH_TOKEN_LOCAL_STORAGE_KEY = "solo.refreshToken";
 
 export const API_PROTOCOL = process.env.REACT_APP_API_PROTOCOL || "https";
 
 export const API_DOMAIN = process.env.REACT_APP_API_DOMAIN;
 
 export const AUTH_DOMAIN = process.env.REACT_APP_AUTH_DOMAIN;
+
+export const BASE_URL = `${API_PROTOCOL}://${API_DOMAIN}`;
 
 export const LOGIN_URL = `${API_PROTOCOL}://${AUTH_DOMAIN}/login/`;
 

--- a/frontend/src/const.ts
+++ b/frontend/src/const.ts
@@ -1,9 +1,11 @@
-export const ACCESS_TOKEN_LOCAL_STORAGE_KEY = "solo.accessToken";
-
-export const REFRESH_TOKEN_LOCAL_STORAGE_KEY = "solo.refreshToken";
+export const TOKEN_LOCAL_STORAGE_KEY = "solo.token";
 
 export const API_PROTOCOL = process.env.REACT_APP_API_PROTOCOL || "https";
 
 export const API_DOMAIN = process.env.REACT_APP_API_DOMAIN;
 
 export const AUTH_DOMAIN = process.env.REACT_APP_AUTH_DOMAIN;
+
+export const LOGIN_URL = `${API_PROTOCOL}://${AUTH_DOMAIN}/login/`;
+
+export const REFRESH_URL = `${API_PROTOCOL}://${AUTH_DOMAIN}/login/refresh/`;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -5,9 +5,9 @@ export interface User {
   username: string;
   userId: string | null;
   authenticated: boolean;
-  tokenExp: string | null;
-  accessToken: string | null;
-  refreshToken: string | null;
+  tokenExp: number | null;
+  refreshExp: number | null;
+  token: string | null;
 }
 
 export const unauthenticatedUser: User = {
@@ -15,27 +15,29 @@ export const unauthenticatedUser: User = {
   userId: null,
   authenticated: false,
   tokenExp: null,
-  accessToken: null,
-  refreshToken: null
+  refreshExp: null,
+  token: null
 };
 
-// pull user information out of a JWT access token
-export const userFromTokens = (
-  accessToken: string | null,
-  refreshToken: string | null
-): User => {
+// pull user information out of token
+export const userFromToken = (token: string | null): User => {
   try {
-    if (!accessToken) {
+    if (!token) {
       return unauthenticatedUser;
     }
-    const { username, user_id: userId, exp } = JwtDecode(accessToken);
+    const {
+      username,
+      user_id: userId,
+      exp,
+      refresh_exp: refreshExp
+    } = JwtDecode(token);
     return {
       username: username,
       userId: userId,
       authenticated: true,
-      tokenExp: exp,
-      accessToken,
-      refreshToken
+      tokenExp: exp * 1000, // convert seconds to miliseconds
+      refreshExp: refreshExp * 1000, // convert seconds to miliseconds
+      token
     };
   } catch (e) {
     return unauthenticatedUser;
@@ -43,8 +45,7 @@ export const userFromTokens = (
 };
 
 export interface AuthContextType extends User {
-  accessToken: string | null;
-  refreshToken: string | null;
+  token: string | null;
   apiCall: <T>(url: string, options: Partial<RequestInit>) => Promise<T>;
   apiLogin: () => Promise<void>;
   apiLogout: () => Promise<void>;

--- a/frontend/src/context/AuthContext.tsx
+++ b/frontend/src/context/AuthContext.tsx
@@ -7,7 +7,8 @@ export interface User {
   authenticated: boolean;
   tokenExp: number | null;
   refreshExp: number | null;
-  token: string | null;
+  accessToken: string | null;
+  refreshToken: string | null;
 }
 
 export const unauthenticatedUser: User = {
@@ -16,28 +17,29 @@ export const unauthenticatedUser: User = {
   authenticated: false,
   tokenExp: null,
   refreshExp: null,
-  token: null
+  accessToken: null,
+  refreshToken: null
 };
 
 // pull user information out of token
-export const userFromToken = (token: string | null): User => {
+export const userFromTokens = (
+  accessToken: string | null,
+  refreshToken: string | null
+): User => {
   try {
-    if (!token) {
+    if (!accessToken || !refreshToken) {
       return unauthenticatedUser;
     }
-    const {
-      username,
-      user_id: userId,
-      exp,
-      refresh_exp: refreshExp
-    } = JwtDecode(token);
+    const { username, user_id: userId, exp } = JwtDecode(accessToken);
+    const { exp: refreshExp } = JwtDecode(refreshToken);
     return {
       username: username,
       userId: userId,
       authenticated: true,
       tokenExp: exp * 1000, // convert seconds to miliseconds
       refreshExp: refreshExp * 1000, // convert seconds to miliseconds
-      token
+      accessToken,
+      refreshToken
     };
   } catch (e) {
     return unauthenticatedUser;
@@ -45,7 +47,6 @@ export const userFromToken = (token: string | null): User => {
 };
 
 export interface AuthContextType extends User {
-  token: string | null;
   apiCall: <T>(url: string, options: Partial<RequestInit>) => Promise<T>;
   apiLogin: () => Promise<void>;
   apiLogout: () => Promise<void>;

--- a/frontend/src/context/AuthContextProvider.tsx
+++ b/frontend/src/context/AuthContextProvider.tsx
@@ -1,16 +1,16 @@
 import React, { useState, useCallback, useEffect } from "react";
 import {
-  ACCESS_TOKEN_LOCAL_STORAGE_KEY,
-  REFRESH_TOKEN_LOCAL_STORAGE_KEY,
+  TOKEN_LOCAL_STORAGE_KEY,
   API_PROTOCOL,
   API_DOMAIN,
-  AUTH_DOMAIN
+  LOGIN_URL,
+  REFRESH_URL
 } from "const";
 import {
   AuthContext,
   User,
   unauthenticatedUser,
-  userFromTokens
+  userFromToken
 } from "./AuthContext";
 
 // to be added to every request
@@ -21,34 +21,72 @@ const baseHeaders: HeadersInit = {
 
 // before rendering, parse any existing user information
 // from token in local storage
-const existingAccessToken = localStorage.getItem(
-  ACCESS_TOKEN_LOCAL_STORAGE_KEY
-);
-const existingRefreshToken = localStorage.getItem(
-  REFRESH_TOKEN_LOCAL_STORAGE_KEY
-);
-const exisitingUser = userFromTokens(existingAccessToken, existingRefreshToken);
+const existingToken = localStorage.getItem(TOKEN_LOCAL_STORAGE_KEY);
+const exisitingUser = userFromToken(existingToken);
 
 const AuthContextProvider: React.FC = ({ children }) => {
   const [currentUser, setCurrentUser] = useState<User>(exisitingUser);
-  const { accessToken, refreshToken, authenticated } = currentUser;
+  const { token, authenticated, tokenExp, refreshExp } = currentUser;
+
+  // refresh a token and set current user based on the new token
+  const refreshToken = useCallback(async () => {
+    try {
+      const res = await fetch(REFRESH_URL, {
+        method: "POST",
+        headers: baseHeaders,
+        body: JSON.stringify({
+          token
+        })
+      });
+      if (!res.ok) {
+        setCurrentUser(unauthenticatedUser);
+      } else {
+        const { token: newToken } = await res.json();
+        setCurrentUser(userFromToken(newToken));
+      }
+    } catch (e) {
+      setCurrentUser(unauthenticatedUser);
+      throw new Error("token refresh failed");
+    }
+  }, [token]);
+
+  // return a promise that checks if the token is required to be
+  // refreshed, and does the refresh prior to resolving. If the
+  // current user is not authenticated, resolve immediately. This
+  // should typically only apply on the first api call for a returning
+  // user, otherwise tokens are automatically refreshed on an interval.
+  const requireRefresh = useCallback(async () => {
+    if (tokenExp && refreshExp) {
+      // expired but refreshable
+      if (Date.now() > tokenExp && Date.now() < refreshExp) {
+        await refreshToken();
+      }
+    }
+  }, [tokenExp, refreshExp, refreshToken]);
+
+  // any time the token changes, set-up automatic token refreshing
+  // every 4 minutes.
+  useEffect(() => {
+    if (authenticated && token) {
+      const interval = setInterval(refreshToken, 1000 * 60); // 4 minutes
+      return () => clearInterval(interval);
+    }
+  }, [token, authenticated, refreshToken]);
 
   // any time the tokens change in state, update local storage
   useEffect(() => {
-    if (authenticated && accessToken && refreshToken) {
-      localStorage.setItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY, accessToken);
-      localStorage.setItem(REFRESH_TOKEN_LOCAL_STORAGE_KEY, refreshToken);
+    if (authenticated && token) {
+      localStorage.setItem(TOKEN_LOCAL_STORAGE_KEY, token);
     } else {
-      localStorage.removeItem(ACCESS_TOKEN_LOCAL_STORAGE_KEY);
-      localStorage.removeItem(REFRESH_TOKEN_LOCAL_STORAGE_KEY);
+      localStorage.removeItem(TOKEN_LOCAL_STORAGE_KEY);
     }
-  }, [authenticated, accessToken, refreshToken]);
+  }, [authenticated, token]);
 
   // add base headers and authentication header to api requests
   const makeOptions = useCallback(
     (options: Partial<RequestInit>): Partial<RequestInit> => {
       const authHeader = currentUser.authenticated && {
-        Authorization: `Bearer ${currentUser.accessToken}`
+        Authorization: `Bearer ${currentUser.token}`
       };
       return {
         ...options,
@@ -59,7 +97,7 @@ const AuthContextProvider: React.FC = ({ children }) => {
         }
       };
     },
-    [currentUser.accessToken, currentUser.authenticated]
+    [currentUser.token, currentUser.authenticated]
   );
 
   // this function is passed to components via context. it wraps the fetch api
@@ -68,6 +106,7 @@ const AuthContextProvider: React.FC = ({ children }) => {
   // return a rejected promise
   const apiCall = useCallback(
     async <T,>(url: string, options: Partial<RequestInit> = {}): Promise<T> => {
+      await requireRefresh();
       const res = await fetch(
         `${API_PROTOCOL}://${API_DOMAIN}${url}`,
         makeOptions(options)
@@ -79,7 +118,7 @@ const AuthContextProvider: React.FC = ({ children }) => {
       }
       return Promise.reject(res);
     },
-    [makeOptions, setCurrentUser]
+    [makeOptions, setCurrentUser, requireRefresh]
   );
 
   // during development, prompt for a username to authenticate as
@@ -96,7 +135,7 @@ const AuthContextProvider: React.FC = ({ children }) => {
   // will authenticate via client SSL certificates (CAC) that are automatically
   // included by the browser if available
   const apiLogin = async () => {
-    const res = await fetch(`${API_PROTOCOL}://${AUTH_DOMAIN}/login/`, {
+    const res = await fetch(LOGIN_URL, {
       headers: apiLoginHeaders(),
       method: "POST",
       body: "{}",
@@ -106,8 +145,8 @@ const AuthContextProvider: React.FC = ({ children }) => {
       setCurrentUser(unauthenticatedUser);
       return Promise.reject(res);
     }
-    const { access, refresh } = await res.json();
-    setCurrentUser(userFromTokens(access, refresh));
+    const { token } = await res.json();
+    setCurrentUser(userFromToken(token));
   };
 
   // clear access and refresh tokens

--- a/frontend/src/hooks/useDocumentApi.ts
+++ b/frontend/src/hooks/useDocumentApi.ts
@@ -97,7 +97,10 @@ const useDocumentApi = () => {
       setPageCount(Math.ceil(count / 25));
       return parseApiDocuments(results);
     },
-    [apiCall, makeQueryString]
+    // we don't need to refresh documents every time a token
+    // refreshes and causes apiCall to change
+    // eslint-disable-next-line
+    [makeQueryString]
   );
 
   return {


### PR DESCRIPTION


Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
~~[ ] attached screenshots illustrating relevant behavior before and after my changes.~~
~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- closes #250 
- update backend to use sliding tokens over refresh tokens
- add refresh token endpoint to backend
- refresh token if required prior to every api call
- refresh tokens on an interval every 4 minutes
- token expires every 5 minutes, and can be refreshed within 24 hours

## Testing
To verify the changes proposed in this pull request…
1. run front and backend unit tests
2. ensure authentication system functions as expected in development environment

## Screenshots
N/A
