### PR TITLE
Bug 238 d6t qty field can now be set to 0

### DIFF
--- a/frontend/src/pages/EnterReceiptPage/QuantityInput.tsx
+++ b/frontend/src/pages/EnterReceiptPage/QuantityInput.tsx
@@ -11,8 +11,9 @@ const QuantityInput: React.FC<QuantityInputProps> = ({
   onQuantitiyChange
 }) => {
   const onValueChange: React.ChangeEventHandler<HTMLInputElement> = e => {
-    const asNum = parseInt(e.currentTarget.value);
-    if (!isNaN(asNum)) {
+    const asNum =
+      e.currentTarget.value === "" ? 0 : parseInt(e.currentTarget.value);
+    if (!Number.isNaN(asNum)) {
       onQuantitiyChange(asNum);
     }
   };

--- a/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPageSubmit.spec.tsx
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/enterReceiptPageSubmit.spec.tsx
@@ -177,6 +177,18 @@ describe("EnterReceiptPage submit all process", () => {
     });
   });
 
+  it("can change the quantitiy to zero", async () => {
+    const { getByPlaceholderText } = await renderAndSearchForDocument();
+    const quantityInp = getByPlaceholderText("Quantity");
+
+    fireEvent.change(quantityInp, {
+      target: { value: "" }
+    });
+    await wait(() => {
+      expect(quantityInp).toHaveValue("0");
+    });
+  });
+
   it("can select a different locator", async () => {
     const { getByPlaceholderText } = await renderAndSearchForDocument();
     const locatorSelect = getByPlaceholderText("Locator");


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- ~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- Closes #238 
- Allows users to change the D6T quantity field by setting a blank input to zero

## Testing
To verify the changes proposed in this pull request…
1. Front-end unit tests
2. On the Enter Receipt (D6T), change the quantity field of a SDN

## Screenshots
![image](https://user-images.githubusercontent.com/59616370/77358891-16ace780-6d21-11ea-9262-659789d2b2ca.png)

