### PR TITLE
moved d6t status indicator alert from below table to above table

### DIFF
--- a/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
+++ b/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
@@ -20,10 +20,8 @@ const EnterReceiptPage: React.FC = () => {
 
   return (
     <div className="tablet:margin-x-8 overflow-x-auto">
-      <div className="grid-row flex-align-start flex-justify">
-        <Title>Enter Receipt</Title>
-        <EnterReceiptStatusIndicator {...submitAllLoadingStatus} />
-      </div>
+      <Title>Enter Receipt</Title>
+      <EnterReceiptStatusIndicator {...submitAllLoadingStatus} />
       <Table<Document>
         columns={columns}
         data={docs}

--- a/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
+++ b/frontend/src/pages/EnterReceiptPage/EnterReceiptPage.tsx
@@ -20,7 +20,10 @@ const EnterReceiptPage: React.FC = () => {
 
   return (
     <div className="tablet:margin-x-8 overflow-x-auto">
-      <Title>Enter Receipt</Title>
+      <div className="grid-row flex-align-start flex-justify">
+        <Title>Enter Receipt</Title>
+        <EnterReceiptStatusIndicator {...submitAllLoadingStatus} />
+      </div>
       <Table<Document>
         columns={columns}
         data={docs}
@@ -40,7 +43,6 @@ const EnterReceiptPage: React.FC = () => {
           Submit All
         </Button>
       </div>
-      <EnterReceiptStatusIndicator {...submitAllLoadingStatus} />
     </div>
   );
 };

--- a/frontend/src/pages/EnterReceiptPage/EnterReceiptStatusIndicator.tsx
+++ b/frontend/src/pages/EnterReceiptPage/EnterReceiptStatusIndicator.tsx
@@ -11,7 +11,7 @@ const EnterReceiptStatusIndicator: React.FC<LoadingStatus> = ({
     {!loading && message && (
       <Alert
         status={error ? "error" : "success"}
-        className="margin-top-4"
+        className="margin-top-1"
         heading={message}
       />
     )}

--- a/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
@@ -5,18 +5,14 @@ exports[`EnterReceiptPage Component matches snapshot 1`] = `
   <div
     class="tablet:margin-x-8 overflow-x-auto"
   >
-    <div
-      class="grid-row flex-align-start flex-justify"
+    <h1
+      class="usa-prose"
     >
-      <h1
-        class="usa-prose"
-      >
-        Enter Receipt
-      </h1>
-      <div
-        class="grid-row flex-justify-center flex-12 tablet:flex-10"
-      />
-    </div>
+      Enter Receipt
+    </h1>
+    <div
+      class="grid-row flex-justify-center flex-12 tablet:flex-10"
+    />
     <table
       class="usa-table grid-col-12 usa-table--borderless"
       role="table"

--- a/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
+++ b/frontend/src/pages/EnterReceiptPage/__tests__/__snapshots__/enterReceiptPage.spec.tsx.snap
@@ -5,11 +5,18 @@ exports[`EnterReceiptPage Component matches snapshot 1`] = `
   <div
     class="tablet:margin-x-8 overflow-x-auto"
   >
-    <h1
-      class="usa-prose"
+    <div
+      class="grid-row flex-align-start flex-justify"
     >
-      Enter Receipt
-    </h1>
+      <h1
+        class="usa-prose"
+      >
+        Enter Receipt
+      </h1>
+      <div
+        class="grid-row flex-justify-center flex-12 tablet:flex-10"
+      />
+    </div>
     <table
       class="usa-table grid-col-12 usa-table--borderless"
       role="table"
@@ -381,9 +388,6 @@ exports[`EnterReceiptPage Component matches snapshot 1`] = `
         Submit All
       </button>
     </div>
-    <div
-      class="grid-row flex-justify-center flex-12 tablet:flex-10"
-    />
   </div>
 </DocumentFragment>
 `;

--- a/frontend/src/solo-uswds/Alert.module.scss
+++ b/frontend/src/solo-uswds/Alert.module.scss
@@ -1,0 +1,3 @@
+.extWidth {
+    width: 100vw;
+}

--- a/frontend/src/solo-uswds/Alert.tsx
+++ b/frontend/src/solo-uswds/Alert.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import classNames from "classnames";
+import classes from "./Alert.module.scss";
 
 interface AlertProps extends Partial<JSX.IntrinsicElements["div"]> {
   status: "success" | "warning" | "error" | "info";
@@ -15,7 +16,12 @@ export const Alert: React.FC<AlertProps> = ({
   ...rest
 }) => (
   <div
-    className={classNames("usa-alert", `usa-alert--${status}`, className)}
+    className={classNames(
+      "usa-alert",
+      `usa-alert--${status}`,
+      className,
+      classes.extWidth
+    )}
     {...rest}
   >
     <div className="usa-alert__body">


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- ~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
- Closes #239 
- On the Enter Receipt D6T page, the status indicator was moved from below the table to above the table to bring the alert to the forefront of the user's attention.

## Testing
To verify the changes proposed in this pull request…
1. run frontend unit tests 

## Screenshots
![image](https://user-images.githubusercontent.com/59616370/77549357-1b3ee080-6e86-11ea-85e6-518f84ae1733.png)


