### PR TITLE
Bug backend filter excluding cor in cor page

### DIFF
--- a/backend/solo_rog_api/filters.py
+++ b/backend/solo_rog_api/filters.py
@@ -8,7 +8,10 @@ class DocumentListFilter(filters.FilterSet):
     nomen = filters.CharFilter(field_name="part__nomen", lookup_expr="icontains")
     commod = filters.CharFilter(field_name="suppadd__desc", lookup_expr="icontains")
     status = filters.CharFilter(
-        field_name="statuses__dic__code", lookup_expr="icontains"
+        field_name="statuses__dic__code", lookup_expr="iexact"
+    )
+    exclude_status = filters.CharFilter(
+        field_name="statuses__dic__code", lookup_expr="iexact", exclude=True
     )
 
     class Meta:

--- a/backend/solo_rog_api/filters.py
+++ b/backend/solo_rog_api/filters.py
@@ -7,9 +7,7 @@ class DocumentListFilter(filters.FilterSet):
     sdn_exact = filters.CharFilter(field_name="sdn", lookup_expr="exact")
     nomen = filters.CharFilter(field_name="part__nomen", lookup_expr="icontains")
     commod = filters.CharFilter(field_name="suppadd__desc", lookup_expr="icontains")
-    status = filters.CharFilter(
-        field_name="statuses__dic__code", lookup_expr="iexact"
-    )
+    status = filters.CharFilter(field_name="statuses__dic__code", lookup_expr="iexact")
     exclude_status = filters.CharFilter(
         field_name="statuses__dic__code", lookup_expr="iexact", exclude=True
     )

--- a/frontend/src/pages/ConfirmationOfReceiptPage/__tests__/confirmationOfReceiptPage.spec.tsx
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/__tests__/confirmationOfReceiptPage.spec.tsx
@@ -38,7 +38,9 @@ describe("ConfirmationOfReceiptPage Component", () => {
     });
     await wait(() => {
       expect(fetchMock).toHaveBeenCalled();
-      expect(fetchMock.mock.calls[0][0]).toEqual("/document/?status=D6T");
+      expect(fetchMock.mock.calls[0][0]).toEqual(
+        "/document/?status=D6T&exclude_status=COR"
+      );
       expect(fetchMock.mock.calls[0][1]).toMatchObject({
         method: "GET"
       });
@@ -69,7 +71,7 @@ describe("ConfirmationOfReceiptPage Component", () => {
       // first call was on render
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(fetchMock.mock.calls[1][0]).toEqual(
-        "/document/?sdn=usersdnfilter&status=D6T"
+        "/document/?sdn=usersdnfilter&status=D6T&exclude_status=COR"
       );
     });
   });
@@ -89,7 +91,7 @@ describe("ConfirmationOfReceiptPage Component", () => {
       // first call was on render
       expect(fetchMock).toHaveBeenCalledTimes(2);
       expect(fetchMock.mock.calls[1][0]).toEqual(
-        "/document/?page=2&status=D6T"
+        "/document/?page=2&status=D6T&exclude_status=COR"
       );
     });
   });

--- a/frontend/src/pages/ConfirmationOfReceiptPage/useCORDocuments.ts
+++ b/frontend/src/pages/ConfirmationOfReceiptPage/useCORDocuments.ts
@@ -28,6 +28,11 @@ const useCORDocuments = () => {
           {
             id: "status",
             value: "D6T"
+          },
+          ...query.filters,
+          {
+            id: "exclude_status",
+            value: "COR"
           }
         ]
       }),


### PR DESCRIPTION
Thanks for submitting a pull request! Below are a few things you can do to help us more quickly review your changes.

## Checklist
I have…
- [x] summarized below my changes and noted which issues (if any) this pull request fixes or addresses.
- [x] thoroughly outlined below the steps necessary to test my changes.
- [x] attached screenshots illustrating relevant behavior before and after my changes.
- ~~[ ] review and update SSAG documentation if needed.~~

## Summary of Changes
This pull request…
- _Add filter param to exclude a status so that the frontend can pass it the correct url param to show the user the latest status of D6T's that hasn't been CORed yet._
- _Update frontend to include the exclude_status param when accessing the /cor page_
- _Update frontend test for the /cor page_

## Testing
To verify the changes proposed in this pull request…
1. _run the pre-hook commit_

## Screenshots
<img width="1310" alt="Screen Shot 2020-03-27 at 4 02 33 PM" src="https://user-images.githubusercontent.com/59840583/77730895-1e33ff80-7045-11ea-8fbd-e69d34ddd656.png">
<img width="1345" alt="Screen Shot 2020-03-27 at 4 02 52 PM" src="https://user-images.githubusercontent.com/59840583/77730901-22601d00-7045-11ea-910f-aa0014861d11.png">
